### PR TITLE
Move repository import paths/references to fermitools organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/shreyb/managed-tokens)](https://goreportcard.com/report/github.com/shreyb/managed-tokens)
-![Go build and test](https://github.com/shreyb/managed-tokens/actions/workflows/go.yml/badge.svg)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/shreyb/managed-tokens)](https://pkg.go.dev/github.com/shreyb/managed-tokens)
+[![Go Report Card](https://goreportcard.com/badge/github.com/fermitools/managed-tokens)](https://goreportcard.com/report/github.com/fermitools/managed-tokens)
+![Go build and test](https://github.com/fermitools/managed-tokens/actions/workflows/go.yml/badge.svg)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/fermitools/managed-tokens)](https://pkg.go.dev/github.com/fermitools/managed-tokens)
 
 
 # managed-tokens

--- a/TODO
+++ b/TODO
@@ -56,12 +56,4 @@ For all TODOs that are more general
 					* condorCreddHostOverride
 					* condorCollectorHostOverride
 		* Build procedure
-	* FIFE
-		* General tokens overview
-		* What tokens go where
-		* What users should expect from managed tokens
-	* Internal DCS wiki (for operators)
-		* Deployment
-		* Configuration on FIFE hardware
-* Get a license for this repo
 * Remove this file from repo.  From this point on, all TODOs should be issues in the github repo

--- a/cmd/refresh-uids-from-ferry/ferryAuthMethods.go
+++ b/cmd/refresh-uids-from-ferry/ferryAuthMethods.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/refresh-uids-from-ferry/ferryAuthMethods.go
+++ b/cmd/refresh-uids-from-ferry/ferryAuthMethods.go
@@ -29,8 +29,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/vaultToken"
-	"github.com/shreyb/managed-tokens/internal/worker"
+	"github.com/fermitools/managed-tokens/internal/vaultToken"
+	"github.com/fermitools/managed-tokens/internal/worker"
 )
 
 // Supported FERRY Authentication methods

--- a/cmd/refresh-uids-from-ferry/main.go
+++ b/cmd/refresh-uids-from-ferry/main.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/refresh-uids-from-ferry/main.go
+++ b/cmd/refresh-uids-from-ferry/main.go
@@ -33,11 +33,11 @@ import (
 	"github.com/spf13/viper"
 	"github.com/yukitsune/lokirus"
 
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/environment"
-	"github.com/shreyb/managed-tokens/internal/metrics"
-	"github.com/shreyb/managed-tokens/internal/notifications"
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/metrics"
+	"github.com/fermitools/managed-tokens/internal/notifications"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 var (

--- a/cmd/refresh-uids-from-ferry/utils.go
+++ b/cmd/refresh-uids-from-ferry/utils.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/refresh-uids-from-ferry/utils.go
+++ b/cmd/refresh-uids-from-ferry/utils.go
@@ -28,13 +28,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/environment"
-	"github.com/shreyb/managed-tokens/internal/kerberos"
-	"github.com/shreyb/managed-tokens/internal/notifications"
-	"github.com/shreyb/managed-tokens/internal/service"
-	"github.com/shreyb/managed-tokens/internal/utils"
-	"github.com/shreyb/managed-tokens/internal/worker"
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/kerberos"
+	"github.com/fermitools/managed-tokens/internal/notifications"
+	"github.com/fermitools/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/worker"
 )
 
 // setupAdminNotifications prepares email and slack messages to be sent to admins in case of errors

--- a/cmd/run-onboarding-managed-tokens/main.go
+++ b/cmd/run-onboarding-managed-tokens/main.go
@@ -29,12 +29,12 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/cmdUtils"
-	"github.com/shreyb/managed-tokens/internal/environment"
-	"github.com/shreyb/managed-tokens/internal/service"
-	"github.com/shreyb/managed-tokens/internal/utils"
-	"github.com/shreyb/managed-tokens/internal/vaultToken"
-	"github.com/shreyb/managed-tokens/internal/worker"
+	"github.com/fermitools/managed-tokens/internal/cmdUtils"
+	"github.com/fermitools/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/vaultToken"
+	"github.com/fermitools/managed-tokens/internal/worker"
 )
 
 var (

--- a/cmd/run-onboarding-managed-tokens/main.go
+++ b/cmd/run-onboarding-managed-tokens/main.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/run-onboarding-managed-tokens/utils.go
+++ b/cmd/run-onboarding-managed-tokens/utils.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/token-push/funcOpts.go
+++ b/cmd/token-push/funcOpts.go
@@ -22,10 +22,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/cmdUtils"
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/service"
-	"github.com/shreyb/managed-tokens/internal/worker"
+	"github.com/fermitools/managed-tokens/internal/cmdUtils"
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/worker"
 )
 
 // Functional option helpers for worker.Config initialization

--- a/cmd/token-push/funcOpts.go
+++ b/cmd/token-push/funcOpts.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -33,15 +33,15 @@ import (
 	"github.com/spf13/viper"
 	"github.com/yukitsune/lokirus"
 
-	"github.com/shreyb/managed-tokens/internal/cmdUtils"
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/environment"
-	"github.com/shreyb/managed-tokens/internal/metrics"
-	"github.com/shreyb/managed-tokens/internal/notifications"
-	"github.com/shreyb/managed-tokens/internal/service"
-	"github.com/shreyb/managed-tokens/internal/utils"
-	"github.com/shreyb/managed-tokens/internal/vaultToken"
-	"github.com/shreyb/managed-tokens/internal/worker"
+	"github.com/fermitools/managed-tokens/internal/cmdUtils"
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/metrics"
+	"github.com/fermitools/managed-tokens/internal/notifications"
+	"github.com/fermitools/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/vaultToken"
+	"github.com/fermitools/managed-tokens/internal/worker"
 )
 
 var (

--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/token-push/main_test.go
+++ b/cmd/token-push/main_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/service"
-	"github.com/shreyb/managed-tokens/internal/testUtils"
+	"github.com/fermitools/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/testUtils"
 )
 
 func TestInitServices(t *testing.T) {

--- a/cmd/token-push/main_test.go
+++ b/cmd/token-push/main_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/token-push/notificationsManager.go
+++ b/cmd/token-push/notificationsManager.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/cmdUtils"
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/notifications"
-	"github.com/shreyb/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/cmdUtils"
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/notifications"
+	"github.com/fermitools/managed-tokens/internal/service"
 )
 
 // General outline of how this works:

--- a/cmd/token-push/notificationsManager.go
+++ b/cmd/token-push/notificationsManager.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/token-push/utils.go
+++ b/cmd/token-push/utils.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/cmdUtils"
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/notifications"
-	"github.com/shreyb/managed-tokens/internal/service"
-	"github.com/shreyb/managed-tokens/internal/utils"
-	"github.com/shreyb/managed-tokens/internal/worker"
+	"github.com/fermitools/managed-tokens/internal/cmdUtils"
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/notifications"
+	"github.com/fermitools/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/worker"
 )
 
 // Prep admin notifications

--- a/cmd/token-push/utils.go
+++ b/cmd/token-push/utils.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/token-push/utils_test.go
+++ b/cmd/token-push/utils_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shreyb/managed-tokens
+module github.com/fermitools/managed-tokens
 
 go 1.21
 

--- a/internal/cmdUtils/cmdUtils.go
+++ b/internal/cmdUtils/cmdUtils.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // cmdUtils provides utilities that are meant to be used by the various executables that the
 // managed tokens library provides
 package cmdUtils

--- a/internal/cmdUtils/cmdUtils.go
+++ b/internal/cmdUtils/cmdUtils.go
@@ -33,7 +33,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/environment"
 )
 
 var (

--- a/internal/cmdUtils/cmdUtils_test.go
+++ b/internal/cmdUtils/cmdUtils_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmdUtils
 
 import (

--- a/internal/cmdUtils/cmdUtils_test.go
+++ b/internal/cmdUtils/cmdUtils_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/testUtils"
+	"github.com/fermitools/managed-tokens/internal/testUtils"
 )
 
 // Helper funcs

--- a/internal/cmdUtils/experimentOverriddenService.go
+++ b/internal/cmdUtils/experimentOverriddenService.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmdUtils
 
 import (

--- a/internal/cmdUtils/experimentOverriddenService.go
+++ b/internal/cmdUtils/experimentOverriddenService.go
@@ -18,7 +18,7 @@ package cmdUtils
 import (
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/service"
 )
 
 // ExperimentOverriddenService is a service where the experiment is overridden.  We want to monitor/act on the config key, but use

--- a/internal/cmdUtils/experimentOverriddenService_test.go
+++ b/internal/cmdUtils/experimentOverriddenService_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmdUtils_test
 
 import (

--- a/internal/cmdUtils/experimentOverriddenService_test.go
+++ b/internal/cmdUtils/experimentOverriddenService_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/shreyb/managed-tokens/internal/cmdUtils"
-	"github.com/shreyb/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/cmdUtils"
+	"github.com/fermitools/managed-tokens/internal/service"
 )
 
 // TestGetServiceName checks that GetServiceName properly returns the name of the

--- a/internal/cmdUtils/scheddCache.go
+++ b/internal/cmdUtils/scheddCache.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmdUtils
 
 import (

--- a/internal/cmdUtils/scheddCollection.go
+++ b/internal/cmdUtils/scheddCollection.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmdUtils
 
 import "sync"

--- a/internal/cmdUtils/scheddCollection_test.go
+++ b/internal/cmdUtils/scheddCollection_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmdUtils
 
 import (

--- a/internal/cmdUtils/scheddCollection_test.go
+++ b/internal/cmdUtils/scheddCollection_test.go
@@ -18,7 +18,7 @@ package cmdUtils
 import (
 	"testing"
 
-	"github.com/shreyb/managed-tokens/internal/testUtils"
+	"github.com/fermitools/managed-tokens/internal/testUtils"
 )
 
 func TestStoreSchedds(t *testing.T) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package db provides the FERRYUIDDatabase struct which provides an interface to a SQLite3 database that is used by the managed tokens
 // utilities to store username-UID mappings, as provided from FERRY.
 package db

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -25,8 +25,9 @@ import (
 	"os"
 
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/shreyb/managed-tokens/internal/utils"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 // Much thanks to K. Retzke - a lot of the boilerplate DB code is adapted from his fifemail application

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db
 
 import (

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/shreyb/managed-tokens/internal/testUtils"
+	"github.com/fermitools/managed-tokens/internal/testUtils"
 )
 
 // TestOpenOrCreateDatabase checks that we can create and reopen a new ManagedTokensDatabase

--- a/internal/db/ferryDb.go
+++ b/internal/db/ferryDb.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db
 
 import (

--- a/internal/db/ferryDb.go
+++ b/internal/db/ferryDb.go
@@ -22,7 +22,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 // SQL Statements

--- a/internal/db/ferryDb_test.go
+++ b/internal/db/ferryDb_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db
 
 import (

--- a/internal/db/ferryDb_test.go
+++ b/internal/db/ferryDb_test.go
@@ -25,7 +25,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/shreyb/managed-tokens/internal/testUtils"
+	"github.com/fermitools/managed-tokens/internal/testUtils"
 )
 
 // TestInsertUidsIntoTableFromFERRY checks that we can insert FERRY data into the ManagedTokensDatabase correctly

--- a/internal/db/migration.go
+++ b/internal/db/migration.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db
 
 import (

--- a/internal/db/migration_test.go
+++ b/internal/db/migration_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db
 
 import (

--- a/internal/db/notificationsDb.go
+++ b/internal/db/notificationsDb.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db
 
 import (

--- a/internal/db/notificationsDb_test.go
+++ b/internal/db/notificationsDb_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db
 
 import (

--- a/internal/db/notificationsDb_test.go
+++ b/internal/db/notificationsDb_test.go
@@ -27,7 +27,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/shreyb/managed-tokens/internal/testUtils"
+	"github.com/fermitools/managed-tokens/internal/testUtils"
 )
 
 // TestGetAllServices checks that GetAllServices correctly retrieves services from the ManagedTokensDatabase

--- a/internal/environment/commandEnvironment.go
+++ b/internal/environment/commandEnvironment.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package environment contains types and functions to assist in passing around environments to be used in commands and wrapping commands in
 // those environments
 package environment

--- a/internal/environment/commandEnvironment_test.go
+++ b/internal/environment/commandEnvironment_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package environment
 
 import (

--- a/internal/environment/environmentWrappers.go
+++ b/internal/environment/environmentWrappers.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package environment
 
 import (

--- a/internal/environment/environmentWrappers_test.go
+++ b/internal/environment/environmentWrappers_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package environment
 
 import (

--- a/internal/environment/environmentWrappers_test.go
+++ b/internal/environment/environmentWrappers_test.go
@@ -20,7 +20,7 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 // TestKerberosEnvironmentWrappedCommand makes sure that KerberosEnvironmentWrappedCommand

--- a/internal/fileCopier/fileCopier.go
+++ b/internal/fileCopier/fileCopier.go
@@ -25,8 +25,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/environment"
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 var fileCopierExecutables map[string]string = map[string]string{

--- a/internal/fileCopier/fileCopier.go
+++ b/internal/fileCopier/fileCopier.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package fileCopier contains interfaces and functions to assist in copying files via ssh.
 package fileCopier
 

--- a/internal/fileCopier/fileCopier_test.go
+++ b/internal/fileCopier/fileCopier_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/shreyb/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/environment"
 )
 
 // TestNewSSHFileCopier asserts that the type of the returned object from NewSSHFileCopier

--- a/internal/fileCopier/fileCopier_test.go
+++ b/internal/fileCopier/fileCopier_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fileCopier
 
 import (

--- a/internal/kerberos/kerberos.go
+++ b/internal/kerberos/kerberos.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package kerberos contains utilities to obtain kerberos tickets, query the kerberos cache, and switch caches in the case of multiple
 // kerberos caches
 package kerberos

--- a/internal/kerberos/kerberos.go
+++ b/internal/kerberos/kerberos.go
@@ -24,8 +24,8 @@ import (
 	"regexp"
 	"text/template"
 
-	"github.com/shreyb/managed-tokens/internal/environment"
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/utils"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/internal/kerberos/kerberos_test.go
+++ b/internal/kerberos/kerberos_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kerberos
 
 import (

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package metrics contains a Prometheus metrics registry that importing code can use to register Prometheus metrics.  When all metrics collection
 // is complete, the PushToPrometheus function can be used to push metrics to a Prometheus Pushgateway server, which is configured through viper.
 package metrics

--- a/internal/notifications/admin.go
+++ b/internal/notifications/admin.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/admin.go
+++ b/internal/notifications/admin.go
@@ -28,8 +28,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/metrics"
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/metrics"
 )
 
 // Metrics

--- a/internal/notifications/admin_test.go
+++ b/internal/notifications/admin_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/db.go
+++ b/internal/notifications/db.go
@@ -21,10 +21,11 @@ import (
 	"errors"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/metrics"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/metrics"
 )
 
 var (

--- a/internal/notifications/db.go
+++ b/internal/notifications/db.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/db_test.go
+++ b/internal/notifications/db_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/db_test.go
+++ b/internal/notifications/db_test.go
@@ -26,8 +26,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/testUtils"
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/testUtils"
 )
 
 // TestSetErrorCountsByServiceNilDBCase checks that if we have a nil ManagedTokensDatabase, that setErrorCountsByService returns a nil

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package notifications contains functions needed to send notifications to the relevant stakeholders for the FIFE Managed Tokens Utilities
 //
 // The two EmailManager funcs here, NewServiceEmailManager, and NewAdminEmailManager, are the primary interfaces by which calling code

--- a/internal/notifications/sendMessage.go
+++ b/internal/notifications/sendMessage.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/sendMessage_test.go
+++ b/internal/notifications/sendMessage_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/serviceEmailManager.go
+++ b/internal/notifications/serviceEmailManager.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/serviceEmailManager.go
+++ b/internal/notifications/serviceEmailManager.go
@@ -25,8 +25,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/metrics"
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/metrics"
 )
 
 // Metrics

--- a/internal/notifications/slackMessage.go
+++ b/internal/notifications/slackMessage.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/tableUtils.go
+++ b/internal/notifications/tableUtils.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/tableUtils_test.go
+++ b/internal/notifications/tableUtils_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/shreyb/managed-tokens/internal/utils"
+
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 // TestPrepareTableStringFromMap checks that PrepareTableStringFromMap properly translates a map into a table

--- a/internal/notifications/tableUtils_test.go
+++ b/internal/notifications/tableUtils_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/template.go
+++ b/internal/notifications/template.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/template_test.go
+++ b/internal/notifications/template_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/notifications/utils.go
+++ b/internal/notifications/utils.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import "sync"

--- a/internal/notifications/utils_test.go
+++ b/internal/notifications/utils_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package notifications
 
 import (

--- a/internal/ping/ping.go
+++ b/internal/ping/ping.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package ping provides utilities to ping a remote host
 package ping
 

--- a/internal/ping/ping.go
+++ b/internal/ping/ping.go
@@ -25,7 +25,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 var (

--- a/internal/ping/ping_test.go
+++ b/internal/ping/ping_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ping
 
 import (

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package service provides the types and related methods to declare, manage, and configure OAuth services (as defined by the HTCondor project).
 // A "service" is used by grid token-retrieving tools to ascertain the correct token issuer, scope, and group memberships that a SciToken should
 // contain.

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package service
 
 import (

--- a/internal/testUtils/testUtils.go
+++ b/internal/testUtils/testUtils.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package testUtils is for testing utilities used across the codebase
 
 package testUtils

--- a/internal/testUtils/testUtils_test.go
+++ b/internal/testUtils/testUtils_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testUtils
 
 import (

--- a/internal/utils/contextKey.go
+++ b/internal/utils/contextKey.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/internal/utils/contextKey_test.go
+++ b/internal/utils/contextKey_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package utils provides general purpose utilities for the various other packages.
 // DEVELOPER NOTE:  This package should ideally NOT depend on any other internal package
 package utils

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/internal/vaultToken/tokenStorer.go
+++ b/internal/vaultToken/tokenStorer.go
@@ -25,8 +25,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/environment"
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 var vaultExecutables = map[string]string{

--- a/internal/vaultToken/tokenStorer.go
+++ b/internal/vaultToken/tokenStorer.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package vaultToken
 
 import (

--- a/internal/vaultToken/tokenStorer_test.go
+++ b/internal/vaultToken/tokenStorer_test.go
@@ -23,8 +23,8 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/shreyb/managed-tokens/internal/environment"
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 type MockTokenStorer struct {

--- a/internal/vaultToken/tokenStorer_test.go
+++ b/internal/vaultToken/tokenStorer_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package vaultToken
 
 import (

--- a/internal/vaultToken/vaultToken.go
+++ b/internal/vaultToken/vaultToken.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package vaultToken provides functions for obtaining and validating Hashicorp vault tokens using the configured HTCondor installation
 package vaultToken
 

--- a/internal/vaultToken/vaultToken.go
+++ b/internal/vaultToken/vaultToken.go
@@ -27,7 +27,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/environment"
 )
 
 // Borrowed from hashicorp's vault API, since we ONLY need this func

--- a/internal/vaultToken/vaultToken_test.go
+++ b/internal/vaultToken/vaultToken_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package vaultToken
 
 import (

--- a/internal/worker/channelsForWorkers.go
+++ b/internal/worker/channelsForWorkers.go
@@ -16,8 +16,8 @@
 package worker
 
 import (
-	"github.com/shreyb/managed-tokens/internal/notifications"
-	"github.com/shreyb/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/notifications"
+	"github.com/fermitools/managed-tokens/internal/service"
 )
 
 // ChannelsForWorkers provides an interface to types that bundle a chan *Config, chan SuccessReporter, and chan notifications.Notification

--- a/internal/worker/channelsForWorkers.go
+++ b/internal/worker/channelsForWorkers.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/channelsForWorkers_test.go
+++ b/internal/worker/channelsForWorkers_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/condorVaultStorerWorker.go
+++ b/internal/worker/condorVaultStorerWorker.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/condorVaultStorerWorker.go
+++ b/internal/worker/condorVaultStorerWorker.go
@@ -25,12 +25,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/environment"
-	"github.com/shreyb/managed-tokens/internal/metrics"
-	"github.com/shreyb/managed-tokens/internal/notifications"
-	"github.com/shreyb/managed-tokens/internal/service"
-	"github.com/shreyb/managed-tokens/internal/utils"
-	"github.com/shreyb/managed-tokens/internal/vaultToken"
+	"github.com/fermitools/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/metrics"
+	"github.com/fermitools/managed-tokens/internal/notifications"
+	"github.com/fermitools/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/vaultToken"
 )
 
 // Metrics

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -25,8 +25,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/environment"
-	"github.com/shreyb/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/service"
 )
 
 // unPingableNodes holds the set of nodes that do not respond to a ping request

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package worker provides worker functions and types that allow callers to abstract away the lower-level details of the various operations needed
 // for the Managed Tokens utilities.  Ideally, most callers should just need to set up worker.Config objects using worker.NewConfig, obtain the worker
 // channels using worker.NewChannelsForWorkers, and call the applicable worker with the above ChannelsForWorkers object.  All that remains then for the

--- a/internal/worker/configFuncOpts.go
+++ b/internal/worker/configFuncOpts.go
@@ -16,7 +16,7 @@
 package worker
 
 import (
-	"github.com/shreyb/managed-tokens/internal/environment"
+	"github.com/fermitools/managed-tokens/internal/environment"
 )
 
 // SetCommandEnvironment is a helper func that takes a variadic of func(*environment.CommandEnvironment) and returns a func(*Config) that sets

--- a/internal/worker/configFuncOpts.go
+++ b/internal/worker/configFuncOpts.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/config_test.go
+++ b/internal/worker/config_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/config_test.go
+++ b/internal/worker/config_test.go
@@ -20,8 +20,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/shreyb/managed-tokens/internal/service"
-	testUtils "github.com/shreyb/managed-tokens/internal/testUtils"
+	"github.com/fermitools/managed-tokens/internal/service"
+	testUtils "github.com/fermitools/managed-tokens/internal/testUtils"
 )
 
 type badFunctionalOptError struct {

--- a/internal/worker/creddVaultTokenStore.go
+++ b/internal/worker/creddVaultTokenStore.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/creddVaultTokenStore_test.go
+++ b/internal/worker/creddVaultTokenStore_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/ferryWorker.go
+++ b/internal/worker/ferryWorker.go
@@ -30,9 +30,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/db"
-	"github.com/shreyb/managed-tokens/internal/metrics"
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/db"
+	"github.com/fermitools/managed-tokens/internal/metrics"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 const ferryRequestDefaultTimeoutStr string = "30s"

--- a/internal/worker/ferryWorker.go
+++ b/internal/worker/ferryWorker.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/kinitWorker.go
+++ b/internal/worker/kinitWorker.go
@@ -24,11 +24,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/kerberos"
-	"github.com/shreyb/managed-tokens/internal/metrics"
-	"github.com/shreyb/managed-tokens/internal/notifications"
-	"github.com/shreyb/managed-tokens/internal/service"
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/kerberos"
+	"github.com/fermitools/managed-tokens/internal/metrics"
+	"github.com/fermitools/managed-tokens/internal/notifications"
+	"github.com/fermitools/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 var (

--- a/internal/worker/kinitWorker.go
+++ b/internal/worker/kinitWorker.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/pingWorker.go
+++ b/internal/worker/pingWorker.go
@@ -25,11 +25,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/metrics"
-	"github.com/shreyb/managed-tokens/internal/notifications"
-	"github.com/shreyb/managed-tokens/internal/ping"
-	"github.com/shreyb/managed-tokens/internal/service"
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/metrics"
+	"github.com/fermitools/managed-tokens/internal/notifications"
+	"github.com/fermitools/managed-tokens/internal/ping"
+	"github.com/fermitools/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 var (

--- a/internal/worker/pingWorker.go
+++ b/internal/worker/pingWorker.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/pingWorker_test.go
+++ b/internal/worker/pingWorker_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/pushTokensWorker.go
+++ b/internal/worker/pushTokensWorker.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (
@@ -350,6 +365,7 @@ func parseDefaultRoleFileDestinationTemplateFromConfig(c *Config) (string, error
 	}
 	return b.String(), nil
 }
+
 // prepareDefaultRoleFile prepares the role file for the given service config
 func prepareDefaultRoleFile(sc *Config) (string, error) {
 	serviceLogger := log.WithFields(log.Fields{

--- a/internal/worker/pushTokensWorker.go
+++ b/internal/worker/pushTokensWorker.go
@@ -29,11 +29,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/shreyb/managed-tokens/internal/fileCopier"
-	"github.com/shreyb/managed-tokens/internal/metrics"
-	"github.com/shreyb/managed-tokens/internal/notifications"
-	"github.com/shreyb/managed-tokens/internal/service"
-	"github.com/shreyb/managed-tokens/internal/utils"
+	"github.com/fermitools/managed-tokens/internal/fileCopier"
+	"github.com/fermitools/managed-tokens/internal/metrics"
+	"github.com/fermitools/managed-tokens/internal/notifications"
+	"github.com/fermitools/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/utils"
 )
 
 // Metrics

--- a/internal/worker/pushTokensWorker_test.go
+++ b/internal/worker/pushTokensWorker_test.go
@@ -23,7 +23,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/shreyb/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/service"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/worker/pushTokensWorker_test.go
+++ b/internal/worker/pushTokensWorker_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/internal/worker/supportedExtrasKey.go
+++ b/internal/worker/supportedExtrasKey.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 // supportedExtrasKey is an enumerated key for the Config.Extras map.  Callers wishing to store values

--- a/internal/worker/supportedExtrasKey_test.go
+++ b/internal/worker/supportedExtrasKey_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shreyb/managed-tokens/internal/service"
+	"github.com/fermitools/managed-tokens/internal/service"
 )
 
 func TestGetVaultTokenStoreHoldoff(t *testing.T) {

--- a/internal/worker/supportedExtrasKey_test.go
+++ b/internal/worker/supportedExtrasKey_test.go
@@ -1,3 +1,18 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (


### PR DESCRIPTION
* Added copyright to top of all source files
* Change import paths and go.mod file to new import path
* Moved repo badges to fermitools org

Closes #3 