### PR TITLE
 Add support for separate vault storer timeout in run-onboarding 

### DIFF
--- a/cmd/run-onboarding-managed-tokens/main.go
+++ b/cmd/run-onboarding-managed-tokens/main.go
@@ -152,7 +152,6 @@ func initConfig() error {
 }
 
 func initServices() error {
-	fmt.Println(pflag.NArg())
 	if pflag.NArg() != 0 && viper.GetString("service") == "" {
 		viper.Set("service", pflag.Arg(0))
 	}

--- a/cmd/run-onboarding-managed-tokens/main.go
+++ b/cmd/run-onboarding-managed-tokens/main.go
@@ -102,8 +102,7 @@ func setup() error {
 		exeLogger.Info("Running in test mode")
 	}
 
-	var err error
-	if timeouts, err = initTimeouts(); err != nil {
+	if err := initTimeouts(); err != nil {
 		log.WithField("executable", currentExecutable).Error("Fatal error setting up timeouts")
 		return err
 	}
@@ -194,8 +193,8 @@ func initLogs() {
 }
 
 // Setup of timeouts, if they're set
-func initTimeouts() (map[string]time.Duration, error) {
-	// Save supported timeouts into timeouts map
+func initTimeouts() error {
+	// Save supported timeouts into global timeouts map
 	for timeoutKey, timeoutString := range viper.GetStringMapString("timeouts") {
 		timeoutKey := strings.TrimSuffix(timeoutKey, "timeout")
 		// Only save the timeout if it's supported, otherwise ignore it
@@ -224,7 +223,7 @@ func initTimeouts() (map[string]time.Duration, error) {
 	if timeForComponentCheck.After(timeForGlobalCheck) {
 		msg := "configured component timeouts exceed the total configured global timeout.  Please check all configured timeouts"
 		exeLogger.Error(msg)
-		return timeouts, errors.New(msg)
+		return errors.New(msg)
 	}
 
 	// If we have a timeout from the command line, override global setting, save timeout in vaultstorer key
@@ -232,7 +231,7 @@ func initTimeouts() (map[string]time.Duration, error) {
 		vaultStorerTimeout, err := time.ParseDuration(timeout)
 		if err != nil {
 			exeLogger.WithField("timeout", timeout).Error("Could not parse timeout duration from command line")
-			return timeouts, err
+			return err
 		}
 		timeouts["vaultstorer"] = vaultStorerTimeout
 
@@ -241,7 +240,7 @@ func initTimeouts() (map[string]time.Duration, error) {
 			timeouts["global"] = vaultStorerTimeout
 		}
 	}
-	return timeouts, nil
+	return nil
 }
 
 func main() {

--- a/cmd/run-onboarding-managed-tokens/main.go
+++ b/cmd/run-onboarding-managed-tokens/main.go
@@ -44,15 +44,16 @@ var (
 	exeLogger         *log.Entry
 )
 
-// Supported timeouts and their default values
+// Supported timeouts that can be read in from configuration file and their default values
 var timeouts = map[string]time.Duration{
-	"global":      time.Duration(300 * time.Second),
-	"kerberos":    time.Duration(20 * time.Second),
-	"vaultstorer": time.Duration(60 * time.Second),
+	"global":   time.Duration(300 * time.Second),
+	"kerberos": time.Duration(20 * time.Second),
 }
 
+var errExitOK = errors.New("exit 0") // Error to return when a function wants to indicate to caller to exit with code 0
+
 // Initial setup.  Read flags, find config file
-func init() {
+func setup() error {
 	// Get current executable name
 	if exePath, err := os.Executable(); err != nil {
 		log.Error("Could not get path of current executable")
@@ -61,18 +62,19 @@ func init() {
 	}
 
 	if err := utils.CheckRunningUserNotRoot(); err != nil {
-		log.WithField("executable", currentExecutable).Fatal("Current user is root.  Please run this executable as a non-root user")
+		log.WithField("executable", currentExecutable).Error("Current user is root.  Please run this executable as a non-root user")
+		return err
 	}
 
 	initFlags()
 	if viper.GetBool("version") {
 		fmt.Printf("Managed tokens libary version %s, build %s\n", version, buildTimestamp)
-		os.Exit(0)
+		return errExitOK
 	}
 
 	if err := initConfig(); err != nil {
 		fmt.Println("Fatal error setting up configuration.  Exiting now")
-		os.Exit(1)
+		return err
 	}
 
 	// If user wants to list all services, do that and exit
@@ -85,18 +87,28 @@ func init() {
 			}
 		}
 		fmt.Println(strings.Join(allServices, "\n"))
-		os.Exit(0)
+		return errExitOK
 	}
 
 	if err := initServices(); err != nil {
 		fmt.Println("Fatal error in parsing service to run onboarding for")
-		os.Exit(1)
+		return err
 	}
 
 	initLogs()
-	if err := initTimeouts(); err != nil {
-		log.WithField("executable", currentExecutable).Fatal("Fatal error setting up timeouts")
+
+	// Test flag sets which notifications section from config we want to use.
+	if viper.GetBool("test") {
+		exeLogger.Info("Running in test mode")
 	}
+
+	var err error
+	if timeouts, err = initTimeouts(); err != nil {
+		log.WithField("executable", currentExecutable).Error("Fatal error setting up timeouts")
+		return err
+	}
+
+	return nil
 }
 
 func initFlags() {
@@ -110,10 +122,11 @@ func initFlags() {
 	pflag.String("admin", "", "Override the config file admin email")
 	pflag.BoolP("verbose", "v", false, "Turn on verbose mode")
 	pflag.Bool("list-services", false, "List all configured services in config file")
+	pflag.String("timeout", "60s", "Timeout for vault_storer portion of run")
+	pflag.StringP("service", "s", "", "Service (experiment_role) to onboard")
 
 	pflag.Parse()
 	viper.BindPFlags(pflag.CommandLine)
-
 }
 
 func initConfig() error {
@@ -139,7 +152,8 @@ func initConfig() error {
 }
 
 func initServices() error {
-	if pflag.NArg() != 0 {
+	fmt.Println(pflag.NArg())
+	if pflag.NArg() != 0 && viper.GetString("service") == "" {
 		viper.Set("service", pflag.Arg(0))
 	}
 
@@ -178,15 +192,10 @@ func initLogs() {
 
 	exeLogger = log.WithField("executable", currentExecutable)
 	exeLogger.Debugf("Using config file %s", viper.ConfigFileUsed())
-
-	// Test flag sets which notifications section from config we want to use.
-	if viper.GetBool("test") {
-		exeLogger.Info("Running in test mode")
-	}
 }
 
 // Setup of timeouts, if they're set
-func initTimeouts() error {
+func initTimeouts() (map[string]time.Duration, error) {
 	// Save supported timeouts into timeouts map
 	for timeoutKey, timeoutString := range viper.GetStringMapString("timeouts") {
 		timeoutKey := strings.TrimSuffix(timeoutKey, "timeout")
@@ -216,12 +225,34 @@ func initTimeouts() error {
 	if timeForComponentCheck.After(timeForGlobalCheck) {
 		msg := "configured component timeouts exceed the total configured global timeout.  Please check all configured timeouts"
 		exeLogger.Error(msg)
-		return errors.New(msg)
+		return timeouts, errors.New(msg)
 	}
-	return nil
+
+	// If we have a timeout from the command line, override global setting, save timeout in vaultstorer key
+	if timeout := viper.GetString("timeout"); timeout != "" {
+		vaultStorerTimeout, err := time.ParseDuration(timeout)
+		if err != nil {
+			exeLogger.WithField("timeout", timeout).Error("Could not parse timeout duration from command line")
+			return timeouts, err
+		}
+		timeouts["vaultstorer"] = vaultStorerTimeout
+
+		if vaultStorerTimeout > timeouts["global"] {
+			exeLogger.Info("Command-line vault_storer timeout exceeds global timeout.  Overriding global timeout")
+			timeouts["global"] = vaultStorerTimeout
+		}
+	}
+	return timeouts, nil
 }
 
 func main() {
+	if err := setup(); err != nil {
+		if errors.Is(err, errExitOK) {
+			os.Exit(0)
+		}
+		log.Fatal("Error running setup actions.  Exiting")
+	}
+
 	var globalTimeout time.Duration
 	var ok bool
 

--- a/cmd/run-onboarding-managed-tokens/main_test.go
+++ b/cmd/run-onboarding-managed-tokens/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitTimeouts2(t *testing.T) {
+	exeLogger = log.NewEntry(log.New())
+	type testCase struct {
+		description      string
+		cmdLineTimeout   string
+		expectedTimeouts map[string]time.Duration
+	}
+
+	testCases := []testCase{
+		{
+			"Timeout less than global",
+			"10s",
+			map[string]time.Duration{
+				"global":      300 * time.Second,
+				"kerberos":    20 * time.Second,
+				"vaultstorer": 10 * time.Second,
+			},
+		},
+		{
+			"Timeout greater than global",
+			"400s",
+			map[string]time.Duration{
+				"global":      400 * time.Second,
+				"kerberos":    20 * time.Second,
+				"vaultstorer": 400 * time.Second,
+			},
+		},
+		{
+			"No timeout given - default used",
+			"60s", // The flag parser would set this value if no flag is given
+			map[string]time.Duration{
+				"global":      300 * time.Second,
+				"kerberos":    20 * time.Second,
+				"vaultstorer": 60 * time.Second,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			timeoutsReset()
+			defer timeoutsReset()
+
+			viper.Set("timeout", tc.cmdLineTimeout)
+
+			timeouts, err := initTimeouts()
+
+			if err != nil {
+				t.Errorf("Expected nil error, but got %s", err)
+				return
+			}
+
+			assert.Equal(t, tc.expectedTimeouts, timeouts)
+		})
+	}
+}
+
+func timeoutsReset() {
+	viper.Reset()
+	timeouts = map[string]time.Duration{
+		"global":   time.Duration(300 * time.Second),
+		"kerberos": time.Duration(20 * time.Second),
+	}
+}

--- a/cmd/run-onboarding-managed-tokens/main_test.go
+++ b/cmd/run-onboarding-managed-tokens/main_test.go
@@ -56,7 +56,7 @@ func TestInitTimeouts(t *testing.T) {
 
 			viper.Set("timeout", tc.cmdLineTimeout)
 
-			timeouts, err := initTimeouts()
+			err := initTimeouts()
 
 			if err != nil {
 				t.Errorf("Expected nil error, but got %s", err)

--- a/cmd/run-onboarding-managed-tokens/main_test.go
+++ b/cmd/run-onboarding-managed-tokens/main_test.go
@@ -1,15 +1,17 @@
 package main
 
 import (
+	"os"
 	"testing"
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInitTimeouts2(t *testing.T) {
+func TestInitTimeouts(t *testing.T) {
 	exeLogger = log.NewEntry(log.New())
 	type testCase struct {
 		description      string
@@ -71,5 +73,60 @@ func timeoutsReset() {
 	timeouts = map[string]time.Duration{
 		"global":   time.Duration(300 * time.Second),
 		"kerberos": time.Duration(20 * time.Second),
+	}
+}
+func TestInitServices(t *testing.T) {
+	type testCase struct {
+		description      string
+		setupFunc        func()
+		expectedErrNil   bool
+		expectedErr      string
+		expecteedService string
+	}
+
+	testCases := []testCase{
+		{
+			"No arguments provided, service not set",
+			func() {},
+			false,
+			"invalid service",
+			"",
+		},
+		{
+			"Argument provided, service not set",
+			func() {
+				pflag.CommandLine.Set("service", "")
+			},
+			false,
+			"invalid service",
+			"",
+		},
+		{
+			"Argument provided, service set",
+			func() {
+				os.Args = []string{"example_service"}
+				pflag.CommandLine.Parse(os.Args)
+				viper.BindPFlags(pflag.CommandLine)
+			},
+			true,
+			"",
+			"example_service",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			viper.Reset()
+			pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+			tc.setupFunc()
+			err := initServices()
+			if tc.expectedErrNil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.expectedErr)
+			}
+			assert.Equal(t, tc.expecteedService, viper.GetString("service"))
+		},
+		)
 	}
 }


### PR DESCRIPTION
This PR, along with the above, also removes the various init() methods.  Those make it very hard to test the code in the main package.