### PR TITLE
Added ability to disable notifications globally or by service

### DIFF
--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -158,12 +158,16 @@ func initFlags() {
 	// Defaults
 	viper.SetDefault("notifications.admin_email", "fife-group@fnal.gov")
 
+	// Aliases
+	viper.RegisterAlias("dont-notify", "disableNotifications")
+
 	// Flags
 	pflag.StringP("experiment", "e", "", "Name of single experiment to push tokens")
 	pflag.StringP("configfile", "c", "", "Specify alternate config file")
 	pflag.StringP("service", "s", "", "Service to obtain and push vault tokens for.  Must be of the form experiment_role, e.g. dune_production")
 	pflag.BoolP("test", "t", false, "Test mode.  Obtain vault tokens but don't push them to nodes")
 	pflag.Bool("version", false, "Version of Managed Tokens library")
+	pflag.Bool("dont-notify", false, "Turn off all notifications for this run")
 	pflag.BoolP("verbose", "v", false, "Turn on verbose mode")
 	pflag.String("admin", "", "Override the config file admin email")
 	pflag.Bool("list-services", false, "List all configured services in config file")

--- a/internal/cmdUtils/disableNotificationsOptions.go
+++ b/internal/cmdUtils/disableNotificationsOptions.go
@@ -1,0 +1,36 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdUtils
+
+// Here we define all the possible ways to disable notifications
+
+type DisableNotificationsOption uint
+
+const (
+	DISABLED_BY_CONFIGURATION DisableNotificationsOption = iota
+	DISABLED_BY_FLAG
+)
+
+func (d DisableNotificationsOption) String() string {
+	switch d {
+	case DISABLED_BY_CONFIGURATION:
+		return "configuration"
+	case DISABLED_BY_FLAG:
+		return "flag"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/cmdUtils/disableNotificationsOptions_test.go
+++ b/internal/cmdUtils/disableNotificationsOptions_test.go
@@ -1,0 +1,49 @@
+// COPYRIGHT 2024 FERMI NATIONAL ACCELERATOR LABORATORY
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdUtils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDisableNotificationsOptionString(t *testing.T) {
+	testCases := []struct {
+		option   DisableNotificationsOption
+		expected string
+	}{
+		{
+			option:   DISABLED_BY_CONFIGURATION,
+			expected: "configuration",
+		},
+		{
+			option:   DISABLED_BY_FLAG,
+			expected: "flag",
+		},
+		{
+			option:   DisableNotificationsOption(999),
+			expected: "unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expected, func(t *testing.T) {
+			result := tc.option.String()
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/cmdUtils/experimentOverriddenService.go
+++ b/internal/cmdUtils/experimentOverriddenService.go
@@ -43,10 +43,12 @@ func NewExperimentOverriddenService(serviceName, configKey string) *ExperimentOv
 	}
 }
 
+// Experiment returns the ExperimentOverriddenService's name that is guaranteed to be unique across all services
 func (e *ExperimentOverriddenService) Experiment() string { return e.ConfigExperiment }
 func (e *ExperimentOverriddenService) Role() string       { return e.Service.Role() }
 
-// Name returns the ExperimentOverriddenService's Service.Name field
+// Name returns the ExperimentOverriddenService's Service.Name field.  If there is another service with the same experiment name in the
+// configuration file, this may not be a unique value across all services.
 func (e *ExperimentOverriddenService) Name() string { return e.Service.Name() }
 
 // ConfigName returns the value stored in the ConfigService key, meant to be a concatenation

--- a/internal/cmdUtils/experimentOverriddenService.go
+++ b/internal/cmdUtils/experimentOverriddenService.go
@@ -33,7 +33,26 @@ type ExperimentOverriddenService struct {
 	ConfigService string
 }
 
-// NewExperimentOverriddenService returns a new *ExperimentOverriddenService by using the service name and configuration key
+// NewExperimentOverriddenService returns a new *ExperimentOverriddenService by using the service name and configuration key that corresponds
+// to the name of the experiment in the configuration.  For example, if there is a configuration:
+// experiments:
+//
+//	experiment1:
+//		roles:
+//			role1:
+//				foo: bar
+//	experiment2:
+//		experimentOverride: experiment1
+//		roles:
+//			role1:
+//				foo: baz
+//
+// Then NewExperimentOverriddenService("experiment1_role1", "experiment2") would return an ExperimentOverriddenService
+// whose Service field would have "experiment1" and "role1" as the experiment and role, respectively; whose ConfigExperiment field would be "experiment2",
+// and whose ConfigService field would be "experiment2_role1".
+//
+// Further, the returned ExperimentOverriddenService's Experiment() method would return "experiment2" rather than "experiment1",
+// the Role() method would return "role1", and the Name() method would return "experiment1_role1"
 func NewExperimentOverriddenService(serviceName, configKey string) *ExperimentOverriddenService {
 	s := service.NewService(serviceName)
 	return &ExperimentOverriddenService{

--- a/managedTokens.yml
+++ b/managedTokens.yml
@@ -11,6 +11,7 @@ defaultRoleFileDestinationTemplate: "/tmp/{{.DesiredUID}}_{{.Account}}"  # Any f
 pingOptions: "--arg1 --arg2 value2" # Options to use with ping
 fileCopierOptions: "--perms --chmod=u=r,go=" # Extra options to give to the fileCopier utility - usually rsync
 sshOptions: "-o Arg1=val1 -o Arg2=val2" # Options to use with fileCopier to establish the SSH connection
+disableNotifications: false # If true, no notifications will be sent
 
 # Optional, and should not be used in production.  Defaults to "production", but can be specified here
 # or with environment variable MANAGED_TOKENS_DEV_ENVIRONMENT_LABEL
@@ -94,11 +95,12 @@ experiments:
         account: dunepro
         destinationNodes: [node1.fnal.gov]
         keytabPathOverride: "/special/path/to/keytab"
-        userPrincipalOverride: "dunepro/managedtokens/fifeutilgpvm01.fnal.gov@FNAL.GOV"
+        userPrincipalOverride: "dunepro/kerberos/principal@REALM"
         desiredUIDOverride: 12345
         condorCreddHostOverride: specialcreddhost.domain
         condorCollectorHostOverride: specialcollectorhost.domain
         defaultRoleFileDestinationTemplateOverride: "/tmp/{{.DesiredUID}}_{{.Account}}"  # Any field in the worker.Config object is supported here
+        disableNotificationsOverride: false # If true, no notifications will be sent for this role
   mu2e:
   # Minimum required configuration
     emails: [email2@example.com]

--- a/managedTokens.yml
+++ b/managedTokens.yml
@@ -87,9 +87,15 @@ notifications_test:
 # Experiment config items
 experiments:
   dune:
-  # Example with overrides
     emails: [email1@example.com]
-    # experimentOverride: thisisactuallynotdune
+    roles:
+      production:
+        account: dunepro
+        destinationNodes: [node1.fnal.gov]
+  dune-2:
+  # Example with overrides including experiment override
+    emails: [email1@example.com]
+    experimentOverride: dune  # Indicates that according to token issuer/storer, this experiment is actually "dune"
     roles:
       production:
         account: dunepro


### PR DESCRIPTION
Closes #92 

### Summary

Rather than allow operators to not specify any email, I added the ability here to allow the administrators to disable notifications either globally or by service.  There are three methods to disable notifications, in order of precedence:

1. Flag:  using the `--dont-notify` or `--disable-notifications` flag.  This will override (2) and (3), and will disable all notifications for that run.
2. Configuration at service-level:  This is accomplished using the `disableNotificationsOverride` entry, set to `true/false` in the role-level configuration in the configuration file.
3. Configuration at the global-level:  This is accomplished using the `disableNotifications` entry in the configuration file.

### Details on precedence

(1) above is simple - it always wins if either version of that flag is set, and no notifications will be sent.

(2) and (3) are a little tricky.  The default behavior is to always send notifications (`disableNotifications` is unset or `false` in configuration file).  Here is a table of possible global and service-level values of `disableNotifications` and `disableNotificationsOverride`, and the resultant behavior of whether the code will send Admin or Service level notifications.

| disableNotifications    | disableNotificationsOverride | Admin Notifications Sent | Service-level notifications sent |
| ---------------------- | ---------------------------- | --------------------------| -------------------------------|
| unset/false | unset/false | yes | yes |
| unset/false | true | yes (but not for disabled service) | no |
| true | unset | no | no |
| true | true | no | no |
| true | false | yes (for only overridden service) | yes |

Note that in the above table, overrides can be set on more than one service, and these rules apply equally to all services.  So, for example, in a three-service configuration, if notifications are disabled globally, but two services indicate that notifications should be sent `disableNotificationsOverride: false`, then the admin notifications are sent for ONLY those two services, and the service notifications are sent for those services as well.  The admin notifications will not contain any errors for the third service, and a service level email for that third service will not be sent.

### Testing 

* Unit tests - PASS
* "Integration tests" - PASS
   * Regular config file - Standard configuration with three experiments, with deliberate errors to check error handling
   * Block some notifications from being sent via config file (only one service allowed through) - should result in admin, one service notification.  Admin notification should only contain information from the one enabled service.
   * Block all notifications globally via config - no notifications should be sent
   * Block only one service via config - other two services should have notifications sent, along with admin notification containing other two services' errors
   * Command-line flags with all of the cases above.  In ALL cases, notifications should not be sent, whether or not the test configuration files have notifications blocked or not.