### PR TITLE
Standardize communication to AdminNotificationManager

### DIFF
--- a/internal/notifications/adminNotificationManager.go
+++ b/internal/notifications/adminNotificationManager.go
@@ -220,11 +220,6 @@ func (a *AdminNotificationManager) runAdminNotificationHandler(ctx context.Conte
 	}()
 }
 
-// GetReceiveChan returns a chan<- Notification on which the AdminNotificationManager can receive Notifications
-func (a *AdminNotificationManager) GetReceiveChan() chan<- Notification {
-	return a.receiveChan
-}
-
 // SourceNotification is a type containing a Notification.  It should be used to send notifications from callers that are sending Notifications to the
 // AdminNotificationManager via a channel gotten via registerNotificationSource.  The notifications/admin package will send all of these types of
 // Notifications - that is, it will not run any checks to determine whether a SourceNotification should be sent.
@@ -234,7 +229,7 @@ type SourceNotification struct {
 
 // registerNotificationSource will return a channel on which callers can send SourceNotifications.  It also spins up a listener goroutine that forwards
 // these Notifications to the AdminNotificationManager's ReceiveChan as long as the context is alive
-func (a *AdminNotificationManager) registerNotificationSource(ctx context.Context) chan<- SourceNotification {
+func (a *AdminNotificationManager) RegisterNotificationSource(ctx context.Context) chan<- SourceNotification {
 	ctx, span := otel.GetTracerProvider().Tracer("managed-tokens").Start(ctx, "notifications.registerNotificationSource")
 	defer span.End()
 

--- a/internal/notifications/adminNotificationManager_test.go
+++ b/internal/notifications/adminNotificationManager_test.go
@@ -425,7 +425,7 @@ func TestRegisterNotificationSource(t *testing.T) {
 	}()
 
 	// Sender
-	sendChan := a.registerNotificationSource(ctx)
+	sendChan := a.RegisterNotificationSource(ctx)
 	go func() {
 		defer close(sendChan)
 		sendChan <- SourceNotification{NewSetupError("message", "service")}

--- a/internal/notifications/serviceEmailManager.go
+++ b/internal/notifications/serviceEmailManager.go
@@ -119,7 +119,7 @@ func NewServiceEmailManager(ctx context.Context, wg *sync.WaitGroup, service str
 		funcLogger.Debug("Not tracking Error counts in ServiceEmailManager")
 	}
 
-	em.adminNotificationChan = em.AdminNotificationManager.registerNotificationSource(ctx)
+	em.adminNotificationChan = em.AdminNotificationManager.RegisterNotificationSource(ctx)
 	em.runServiceNotificationHandler(ctx)
 
 	return em


### PR DESCRIPTION
Removed notifications.AdminNotificationManager.GetReceiveChan - all communication to AdminNotificationManager should happen through the channel returned by AdminNotificationManager.RegisterNotificationSource.

This change involved doing the following:

1. Removing the AdminNotificationManager.GetReceiveChan method
2. Exporting AdminNotificationManager.RegisterNotificationSource method so other packages can use it
3. Updating `refresh-uids-from-ferry` and `token-push` to register the executable main goroutines using `RegisterNotificationSource`.

To accomplish (3), I had to change some helper function signatures (like the `setupAdminNotifications` funcs in each executable package).