### PR TITLE
Add failover capability for collectors

### DIFF
--- a/cmd/run-onboarding-managed-tokens/main.go
+++ b/cmd/run-onboarding-managed-tokens/main.go
@@ -84,6 +84,7 @@ func setup() error {
 		fmt.Println("Fatal error setting up configuration.  Exiting now")
 		return err
 	}
+	initEnvironment()
 
 	devEnvironmentLabel = getDevEnvironmentLabel()
 
@@ -158,6 +159,13 @@ func initConfig() error {
 		return err
 	}
 	return nil
+}
+
+// Environment variables to read into Viper config
+// Note: In keeping with best practices, these can be overridden by command line flags or direct
+// in-code overrides.  This only sets the initial state of the given viper keys.
+func initEnvironment() {
+	viper.BindEnv("collectorHost", environment.CondorCollectorHost.EnvVarKey())
 }
 
 func initServices() error {
@@ -371,12 +379,12 @@ func run(ctx context.Context) error {
 		tracing.LogErrorWithTrace(span, funcLogger, "Cannot proceed without vault server.  Exiting")
 		return err
 	}
-	schedds, err := cmdUtils.GetScheddsFromConfiguration(ctx, serviceConfigPath)
+	collectorHost, schedds, err := cmdUtils.GetScheddsAndCollectorHostFromConfiguration(ctx, serviceConfigPath)
 	if err != nil {
 		tracing.LogErrorWithTrace(span, funcLogger, "Cannot proceed without schedds.  Exiting")
 		return err
 	}
-	collectorHost := cmdUtils.GetCondorCollectorHostFromConfiguration(serviceConfigPath)
+
 	keytabPath := cmdUtils.GetKeytabFromConfiguration(serviceConfigPath)
 	serviceCreddVaultTokenPathRoot := cmdUtils.GetServiceCreddVaultTokenPathRoot(serviceConfigPath)
 	serviceConfig, err = worker.NewConfig(

--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -600,7 +600,7 @@ func run(ctx context.Context) error {
 		go func(s service.Service) {
 			funcLogger := exeLogger.WithFields(log.Fields{
 				"caller":  "token-push.run",
-				"service": s.Name(),
+				"service": cmdUtils.GetServiceName(s),
 			})
 
 			// Setup the configs

--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -217,6 +217,13 @@ func disableNotifyFlagWorkaround() {
 	}
 }
 
+// Environment variables to read into Viper config
+// Note: In keeping with best practices, these can be overridden by command line flags or direct
+// in-code overrides.  This only sets the initial state of the given viper keys.
+func initEnvironment() {
+	viper.BindEnv("collectorHost", environment.CondorCollectorHost.EnvVarKey())
+}
+
 // Set up logs
 func initLogs() {
 	log.SetLevel(log.DebugLevel)
@@ -631,7 +638,7 @@ func run(ctx context.Context) error {
 				collectFailedServiceSetups <- cmdUtils.GetServiceName(s)
 				return
 			}
-			schedds, err := cmdUtils.GetScheddsFromConfiguration(ctx, serviceConfigPath)
+			collectorHost, schedds, err := cmdUtils.GetScheddsAndCollectorHostFromConfiguration(ctx, serviceConfigPath)
 			if err != nil {
 				tracing.LogErrorWithTrace(span, funcLogger, "Cannot proceed without schedds. Returning now")
 				collectFailedServiceSetups <- cmdUtils.GetServiceName(s)
@@ -639,7 +646,6 @@ func run(ctx context.Context) error {
 			}
 
 			// Service-level configuration items that can be defined either in configuration file or on system/environment or have library defaults
-			collectorHost := cmdUtils.GetCondorCollectorHostFromConfiguration(serviceConfigPath)
 			keytabPath := cmdUtils.GetKeytabFromConfiguration(serviceConfigPath)
 			defaultRoleFileDestinationTemplate := getDefaultRoleFileDestinationTemplate(serviceConfigPath)
 			serviceCreddVaultTokenPathRoot := cmdUtils.GetServiceCreddVaultTokenPathRoot(serviceConfigPath)

--- a/internal/cmdUtils/cmdUtils.go
+++ b/internal/cmdUtils/cmdUtils.go
@@ -186,8 +186,8 @@ func GetScheddsAndCollectorHostFromConfiguration(ctx context.Context, checkServi
 
 	// 2.  Try globalScheddCache
 	// See if we already have created a cacheEntry in the globalScheddCache for the collectorHost
-	scheddSourceForLog := "cache"
 	for _, collectorHostEntry := range collectorHostEntries {
+		scheddSourceForLog := "cache"
 		cacheEntry, _ := globalScheddCache.cache.LoadOrStore(
 			collectorHostEntry,
 			&scheddCacheEntry{

--- a/internal/cmdUtils/cmdUtils.go
+++ b/internal/cmdUtils/cmdUtils.go
@@ -48,12 +48,6 @@ var (
 
 // Functional options for initialization of service Config
 
-// GetCondorCollectorHostFromConfiguration gets the _condor_COLLECTOR_HOST environment variable from the Viper configuration
-func GetCondorCollectorHostFromConfiguration(checkServiceConfigPath string) string {
-	condorCollectorHostPath, _ := GetServiceConfigOverrideKeyOrGlobalKey(checkServiceConfigPath, "condorCollectorHost")
-	return viper.GetString(condorCollectorHostPath)
-}
-
 // GetUserPrincipalFromConfiguration gets the configured kerberos principal
 func GetUserPrincipalFromConfiguration(checkServiceConfigPath string) string {
 	if userPrincipalOverrideConfigPath, ok := GetServiceConfigOverrideKeyOrGlobalKey(checkServiceConfigPath, "userPrincipal"); ok {
@@ -160,16 +154,26 @@ func GetKeytabFromConfiguration(checkServiceConfigPath string) string {
 	}
 }
 
-// GetScheddsFromConfiguration gets the schedd names that match the configured constraint by querying the condor collector.  It can be overridden
-// by setting the checkServiceConfigPath's condorCreddHostOverride field, in which case that value will be set as the schedd
-func GetScheddsFromConfiguration(ctx context.Context, checkServiceConfigPath string) ([]string, error) {
+// GetScheddsAndCollectorHostFromConfiguration gets the schedd names that match the configured constraint by querying the condor collector.  It can be overridden
+// by setting the checkServiceConfigPath's condorCreddHostOverride field, in which case that value will be set as the schedd. It returns
+// the collector host used, and the list of schedds that were found.  If no valid collector host or schedds are found, an error is returned.
+func GetScheddsAndCollectorHostFromConfiguration(ctx context.Context, checkServiceConfigPath string) (string, []string, error) {
 	funcLogger := log.WithField("serviceConfigPath", checkServiceConfigPath)
 	ctx, span := otel.Tracer("managed-tokens").Start(ctx, "cmdUtils.GetScheddsFromConfiguration")
 	span.SetAttributes(attribute.KeyValue{Key: "checkServiceConfigPath", Value: attribute.StringValue(checkServiceConfigPath)})
 	defer span.End()
 
+	collectorHostString := GetCondorCollectorHostFromConfiguration(checkServiceConfigPath)
+	if collectorHostString == "" {
+		msg := "no collector hosts found"
+		span.SetStatus(codes.Error, msg)
+		funcLogger.Error(msg)
+		return "", nil, errors.New(msg)
+	}
+	collectorHostEntries := strings.Split(collectorHostString, ",")
+
 	// 1. Try override
-	// If condorCreddHostOverride is set either globally or at service level, set the schedd slice to that
+	// If condorCreddHostOverride is set either globally or at service level, set the schedd slice to that, and return first collector host
 	schedds, found := checkScheddsOverride(checkServiceConfigPath)
 	if found {
 		span.SetStatus(codes.Ok, "Schedds successfully retrieved from override")
@@ -177,51 +181,70 @@ func GetScheddsFromConfiguration(ctx context.Context, checkServiceConfigPath str
 			attribute.KeyValue{Key: "scheddInfoSource", Value: attribute.StringValue("override")},
 			attribute.KeyValue{Key: "schedds", Value: attribute.StringValue(strings.Join(schedds, ","))},
 		)
-		return schedds, nil
+		return collectorHostEntries[0], schedds, nil
 	}
 
 	// 2.  Try globalScheddCache
 	// See if we already have created a cacheEntry in the globalScheddCache for the collectorHost
 	scheddSourceForLog := "cache"
-	collectorHost := GetCondorCollectorHostFromConfiguration(checkServiceConfigPath)
-	cacheEntry, _ := globalScheddCache.cache.LoadOrStore(
-		collectorHost,
-		&scheddCacheEntry{
-			newScheddCollection(),
-			&sync.Once{},
-		},
-	)
-
-	// Now that we have our *scheddCacheEntry (either new or preexisting), if its *sync.Once has not been run, do so now to populate the entry.
-	// If the Once has already been run, it will wait until the first Once has completed before resuming execution.
-	// This way we are guaranteed that the cache will always be populated.
-	var err error
-	cacheEntryVal, ok := cacheEntry.(*scheddCacheEntry)
-	if ok {
-		cacheEntryVal.once.Do(
-			func() {
-				// 3.  Query collector
-				// At this point, we haven't queried this collector yet.  Do so, and store its schedds in the global store/cache
-				scheddSourceForLog = "collector"
-				constraint := getConstraintFromConfiguration(checkServiceConfigPath)
-				err = cacheEntryVal.populateFromCollector(ctx, collectorHost, constraint)
+	for _, collectorHostEntry := range collectorHostEntries {
+		cacheEntry, _ := globalScheddCache.cache.LoadOrStore(
+			collectorHostEntry,
+			&scheddCacheEntry{
+				newScheddCollection(),
+				&sync.Once{},
 			},
 		)
-		if err != nil {
-			span.SetStatus(codes.Error, "Could not populate schedd cache from collector")
-			return nil, err
+
+		// Now that we have our *scheddCacheEntry (either new or preexisting), if its *sync.Once has not been run, do so now to populate the entry.
+		// If the Once has already been run, it will wait until the first Once has completed before resuming execution.
+		// This way we are guaranteed that the cache will always be populated.
+		var err error
+		cacheEntryVal, ok := cacheEntry.(*scheddCacheEntry)
+		if ok {
+			cacheEntryVal.once.Do(
+				func() {
+					// 3.  Query collector
+					// At this point, we haven't queried this collector yet.  Do so, and store its schedds in the global store/cache
+					ctx, span := otel.Tracer("managed-tokens").Start(ctx, "cmdUtils.GetScheddsFromConfiguration.queryCollAnonFunc")
+					span.SetAttributes(attribute.KeyValue{Key: "collectorHost", Value: attribute.StringValue(collectorHostEntry)})
+					defer span.End()
+
+					scheddSourceForLog = "collector"
+					constraint := getConstraintFromConfiguration(checkServiceConfigPath)
+					err = cacheEntryVal.populateFromCollector(ctx, collectorHostEntry, constraint)
+					span.SetStatus(codes.Error, "Could not populate schedd cache from collector")
+				},
+			)
+			if err != nil {
+				continue
+			}
 		}
+
+		// Load schedds from cache, which we either just populated, or are only reading from; then return those schedds
+		schedds = cacheEntryVal.scheddCollection.getSchedds()
+		funcLogger.WithFields(log.Fields{
+			"schedds":       schedds,
+			"collectorHost": collectorHostEntry,
+		}).Debugf("Set schedds successfully from %s", scheddSourceForLog)
+		span.SetAttributes(attribute.KeyValue{Key: "scheddInfoSource", Value: attribute.StringValue(scheddSourceForLog)})
+		span.SetStatus(codes.Ok, "Schedds successfully retrieved")
+		return collectorHostEntry, schedds, nil
 	}
 
-	// Load schedds from cache, which we either just populated, or are only reading from; then return those schedds
-	schedds = cacheEntryVal.scheddCollection.getSchedds()
-	funcLogger.WithFields(log.Fields{
-		"schedds":       schedds,
-		"collectorHost": collectorHost,
-	}).Debugf("Set schedds successfully from %s", scheddSourceForLog)
-	span.SetAttributes(attribute.KeyValue{Key: "scheddInfoSource", Value: attribute.StringValue(scheddSourceForLog)})
-	span.SetStatus(codes.Ok, "Schedds successfully retrieved")
-	return schedds, nil
+	// All attempts to get schedds have failed
+	msg := "could not retrieve schedds from configured collectors"
+	span.SetStatus(codes.Error, msg)
+	return "", nil, errors.New(msg)
+}
+
+// GetCondorCollectorHostFromConfiguration gets the condor collector host from the Viper configuration which will be used to populate
+// the _condor_COLLECTOR_HOST environment variable.
+// It is preferred to use GetScheddsAndCollectorHostFromConfiguration to get the collector host, as it will also populate the schedd cache
+// and handle failovers
+func GetCondorCollectorHostFromConfiguration(checkServiceConfigPath string) string {
+	condorCollectorHostPath, _ := GetServiceConfigOverrideKeyOrGlobalKey(checkServiceConfigPath, "condorCollectorHost")
+	return viper.GetString(condorCollectorHostPath)
 }
 
 // checkScheddsOverride checks the global and service-level configurations for the condorCreddHost key.  If that key exists, the value

--- a/internal/cmdUtils/cmdUtils_test.go
+++ b/internal/cmdUtils/cmdUtils_test.go
@@ -396,9 +396,13 @@ func TestGetScheddsAndCollectorHostFromConfigurationCached(t *testing.T) {
 	cacheEntry := &scheddCacheEntry{
 		newScheddCollection(),
 		once,
+		nil,
 	}
 	cacheEntry.storeSchedds(schedds)
-	globalScheddCache.cache.Store(collectorHost, cacheEntry)
+
+	globalScheddCache.mu.Lock()
+	globalScheddCache.cache[collectorHost] = cacheEntry
+	globalScheddCache.mu.Unlock()
 
 	// test
 	resultCollector, resultSchedds, err := GetScheddsAndCollectorHostFromConfiguration(ctx, "fakeservicepath")
@@ -429,9 +433,12 @@ func TestGetScheddsAndCollectorHostFromConfigurationFallback(t *testing.T) {
 	cacheEntry := &scheddCacheEntry{
 		newScheddCollection(),
 		once,
+		nil,
 	}
 	cacheEntry.storeSchedds(schedds)
-	globalScheddCache.cache.Store("myCollectorHost2", cacheEntry)
+	globalScheddCache.mu.Lock()
+	globalScheddCache.cache["myCollectorHost2"] = cacheEntry
+	globalScheddCache.mu.Unlock()
 
 	// test
 	resultCollector, resultSchedds, err := GetScheddsAndCollectorHostFromConfiguration(ctx, "")

--- a/internal/cmdUtils/scheddCache.go
+++ b/internal/cmdUtils/scheddCache.go
@@ -25,16 +25,18 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-// scheddCache is a cache where the schedds corresponding to each collector are stored.  It is a container for a sync.Map,
-// which contains a map[string]*scheddCacheEntry, where the key is the collector host
+// scheddCache is a cache where the schedds corresponding to each collector are stored.  It is a container for a map[string]*scheddCacheEntry,
+// where the key is the collector host, and a mutex to control access to this map
 type scheddCache struct {
-	cache sync.Map
+	cache map[string]*scheddCacheEntry
+	mu    *sync.Mutex
 }
 
 // scheddCacheEntry is an entry that contains a *scheddCollection and a *sync.Once to ensure that it is populated exactly once
 type scheddCacheEntry struct {
 	*scheddCollection
 	once *sync.Once
+	err  error // error encountered while populating the cache entry
 }
 
 // populateFromCollector queries the condor collector for the schedds and stores them in scheddCacheEntry


### PR DESCRIPTION
This allows operators to configure collector hosts as follows:

```yaml
condorCollectorHost: "collector1,collector2"
```
to allow for failover behavior.

The changes are as follows:

1. Changed `cmdUtils.GetScheddsFromConfiguration` to `cmdUtils.GetScheddsAndCollectorHostFromConfiguration`.  As the name implies, the function now returns the collector and the schedds.
2. Changes in types of `cmd.scheddCache` and `cmd.scheddCacheEntry`
3. `cmdUtils.GetScheddsAndCollectorHostFromConfiguration` uses changes in (2), and implements failover.  When a string of more than one collector is given (like in example above), it will try to query `collector1.  If that fails, the error is stored in the corresponding `scheddCacheEntry` so future calls to the same collector are not retried.  Then, it will try to query `collector2`.