### PR TITLE
Implement --dont-notify flag for `refresh-uids-from-ferry`

### DIFF
--- a/cmd/refresh-uids-from-ferry/main.go
+++ b/cmd/refresh-uids-from-ferry/main.go
@@ -510,7 +510,7 @@ func run(ctx context.Context) error {
 				usernameCtx, span := otel.GetTracerProvider().Tracer("refresh-uids-from-ferry").Start(ferryContext, "get-ferry-data-per-username_anonFunc")
 				span.SetAttributes(attribute.KeyValue{Key: "username", Value: attribute.StringValue(username)})
 				defer span.End()
-				return getAndAggregateFERRYData(usernameCtx, username, authFunc, ferryDataChan, aReceiveChan) // TODO Will have to look inside this func and disable sending if we don't want notifications
+				return getAndAggregateFERRYData(usernameCtx, username, authFunc, ferryDataChan, aReceiveChan)
 			})
 		}
 		// Don't close data channel until all workers have put their data in

--- a/cmd/refresh-uids-from-ferry/main.go
+++ b/cmd/refresh-uids-from-ferry/main.go
@@ -518,9 +518,6 @@ func run(ctx context.Context) error {
 			// It's OK if we have an error - just log it and move on so we can work with what data did come back
 			msg := "Error getting FERRY data for one of the usernames.  Please investigate"
 			tracing.LogErrorWithTrace(span, exeLogger, msg)
-			if !viper.GetBool("disableNotifications") {
-				sendSetupErrorToAdminMgr(aReceiveChan, msg)
-			}
 		}
 	}()
 

--- a/cmd/refresh-uids-from-ferry/main.go
+++ b/cmd/refresh-uids-from-ferry/main.go
@@ -168,7 +168,6 @@ func disableNotifyFlagWorkaround() {
 		viper.Set("disableNotifications", true)
 		notificationsDisabledBy = cmdUtils.DISABLED_BY_FLAG
 	}
-	exeLogger.Debug("Notifications disabled by " + notificationsDisabledBy.String())
 }
 
 func initConfig() error {
@@ -362,6 +361,10 @@ func run(ctx context.Context) error {
 		span.SetAttributes(attribute.KeyValue{Key: "test", Value: attribute.BoolValue(true)})
 	}
 	defer span.End()
+
+	if viper.GetBool("disableNotifications") {
+		exeLogger.Debugf("Notifications disabled by %s", notificationsDisabledBy.String())
+	}
 
 	var dbLocation string
 	// Open connection to the SQLite database where UID info will be stored

--- a/cmd/refresh-uids-from-ferry/utils_test.go
+++ b/cmd/refresh-uids-from-ferry/utils_test.go
@@ -16,6 +16,10 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -24,6 +28,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/fermitools/managed-tokens/internal/db"
 	"github.com/fermitools/managed-tokens/internal/notifications"
 	"github.com/fermitools/managed-tokens/internal/testUtils"
 )
@@ -140,4 +145,86 @@ func TestSendSetupErrorToAdminMgr(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return <-done
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestGetAndAggregateFERRYData(t *testing.T) {
+	nonNilErr := errors.New("this is a test error")
+
+	type testCase struct {
+		description       string
+		username          string
+		authFunc          func() func(context.Context, string, string) (*http.Response, error)
+		ferryDataChan     chan db.FerryUIDDatum
+		notificationsChan chan notifications.SourceNotification
+		expectedErr       error
+	}
+
+	testCases := []testCase{
+		{
+			"error getting ferry data",
+			"test_user",
+			func() func(context.Context, string, string) (*http.Response, error) {
+				return func(ctx context.Context, url, verb string) (*http.Response, error) {
+					return nil, errors.New("this is a test error")
+				}
+			},
+			// buffer these channels so we can send values without preemptively starting up listeners like we normally would
+			make(chan db.FerryUIDDatum, 1),
+			make(chan notifications.SourceNotification, 1),
+			nonNilErr,
+		},
+		{
+			"no error getting ferry data",
+			"test_user",
+			func() func(context.Context, string, string) (*http.Response, error) {
+				return func(ctx context.Context, url, verb string) (*http.Response, error) {
+					fakeResponseBody := `{"ferry_status":"success","ferry_error":[],"ferry_output":{"expirationdate":"2024-01-01T00:00:00Z","fullname":"Test User","groupaccount":false,"status":true,"uid":12345,"vopersonid":"12345"}}`
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(strings.NewReader(fakeResponseBody)),
+					}, nil
+				}
+			},
+			// buffer these channels so we can send values without preemptively starting up listeners like we normally would
+			make(chan db.FerryUIDDatum, 1),
+			make(chan notifications.SourceNotification, 1),
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.username, func(t *testing.T) {
+			defer close(tc.ferryDataChan)
+			defer close(tc.notificationsChan)
+			err := getAndAggregateFERRYData(context.Background(), tc.username, tc.authFunc, tc.ferryDataChan, tc.notificationsChan)
+			assert.Equal(t, tc.expectedErr, err)
+
+			if tc.expectedErr != nil {
+				// If there is no expected error, we check that a notification got sent.  We don't care in this case about the contents
+				// of the notification, just that one was sent
+				testCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+				defer cancel()
+
+				select {
+				case <-testCtx.Done():
+					t.Error("Expected to receive a notification, but none received")
+				case <-tc.notificationsChan:
+					// This is the expected behavior, so we do nothing and let the test continue
+				}
+				return
+			}
+
+			// At this point, we don't expect an error, so the entry should have gotten sent on the ferryDataChan. Like before, we don't
+			// care about the contents of the entry, just that one was sent
+			testCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			select {
+			case <-testCtx.Done():
+				t.Error("Expected to receive a notification, but none received")
+			case <-tc.ferryDataChan:
+				// This is the expected behavior
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR implements the `--dont-notify` flag and the corresponding `disableNotifications` configuration option for the `refresh-uids-from-ferry` executable.

The changes are as follows:

1.  As stated above, we have a new `--dont-notify` flag that disables the email and slack message that get sent if there are errors in a run of `refresh-uids-from-ferry`.
2. `getAndAggregateFERRYData` now returns an error.  This makes it more idiomatic, and testable (a test is added in this PR as well)
3. The `run` function in `main.go` will now use the new signature of `getAndAggregateFERRYData` to look for errors.  Since this is done concurrently, I switched the running of all the `getAndAggregateFERRYData` functions from using goroutines synchronized by waitgroups to an errgroup.Group, which basically does the same thing, but lets you check for any errors in all of those goroutines.  The previous implementation would have had to ignore any errors.
4. Minor bug fix in `token-push`, if no emails were given for an experiment in a configuration.  This was supposed to be implemented in #92, but I missed it then.