### PR TITLE
Always print version at beginning of executable run

### DIFF
--- a/cmd/refresh-uids-from-ferry/main.go
+++ b/cmd/refresh-uids-from-ferry/main.go
@@ -102,17 +102,21 @@ func setup() error {
 	} else {
 		currentExecutable = path.Base(exePath)
 	}
+	setupLogger := log.WithField("executable", currentExecutable)
 
 	if err := utils.CheckRunningUserNotRoot(); err != nil {
-		log.WithField("executable", currentExecutable).Error("Current user is root.  Please run this executable as a non-root user")
+		setupLogger.Error("Current user is root.  Please run this executable as a non-root user")
 		return err
 	}
 
 	initFlags() // Parse our flags
+
+	versionMessage := fmt.Sprintf("Managed tokens library version %s, build %s", version, buildTimestamp)
 	if viper.GetBool("version") {
-		fmt.Printf("Managed tokens library version %s, build %s\n", version, buildTimestamp)
+		fmt.Println(versionMessage)
 		return errExitOK
 	}
+	setupLogger.Info(versionMessage)
 
 	if err := initConfig(); err != nil {
 		fmt.Println("Fatal error setting up configuration.  Exiting now")
@@ -127,11 +131,11 @@ func setup() error {
 
 	initLogs()
 	if err := initTimeouts(); err != nil {
-		log.WithField("executable", currentExecutable).Error("Fatal error setting up timeouts")
+		setupLogger.Error("Fatal error setting up timeouts")
 		return err
 	}
 	if err := initMetrics(); err != nil {
-		log.WithField("executable", currentExecutable).Error("Error setting up metrics")
+		setupLogger.Error("Error setting up metrics. Will still continue")
 	}
 
 	return nil

--- a/cmd/run-onboarding-managed-tokens/main.go
+++ b/cmd/run-onboarding-managed-tokens/main.go
@@ -68,17 +68,21 @@ func setup() error {
 	} else {
 		currentExecutable = path.Base(exePath)
 	}
+	setupLogger := log.WithField("executable", currentExecutable)
 
 	if err := utils.CheckRunningUserNotRoot(); err != nil {
-		log.WithField("executable", currentExecutable).Error("Current user is root.  Please run this executable as a non-root user")
+		setupLogger.Error("Current user is root.  Please run this executable as a non-root user")
 		return err
 	}
 
 	initFlags()
+
+	versionMessage := fmt.Sprintf("Managed tokens libary version %s, build %s", version, buildTimestamp)
 	if viper.GetBool("version") {
-		fmt.Printf("Managed tokens libary version %s, build %s\n", version, buildTimestamp)
+		fmt.Println(versionMessage)
 		return errExitOK
 	}
+	setupLogger.Info(versionMessage)
 
 	if err := initConfig(); err != nil {
 		fmt.Println("Fatal error setting up configuration.  Exiting now")
@@ -102,7 +106,7 @@ func setup() error {
 	}
 
 	if err := initServices(); err != nil {
-		fmt.Println("Fatal error in parsing service to run onboarding for")
+		setupLogger.Error("Fatal error in parsing service to run onboarding for")
 		return err
 	}
 
@@ -110,11 +114,11 @@ func setup() error {
 
 	// Test flag sets which notifications section from config we want to use.
 	if viper.GetBool("test") {
-		exeLogger.Info("Running in test mode")
+		setupLogger.Info("Running in test mode")
 	}
 
 	if err := initTimeouts(); err != nil {
-		log.WithField("executable", currentExecutable).Error("Fatal error setting up timeouts")
+		setupLogger.Error("Fatal error setting up timeouts")
 		return err
 	}
 

--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -115,17 +115,21 @@ func setup() error {
 	} else {
 		currentExecutable = path.Base(exePath)
 	}
+	setupLogger := log.WithField("executable", currentExecutable)
 
 	if err := utils.CheckRunningUserNotRoot(); err != nil {
-		log.WithField("executable", currentExecutable).Error("Current user is root.  Please run this executable as a non-root user")
+		setupLogger.Error("Current user is root.  Please run this executable as a non-root user")
 		return err
 	}
 
 	initFlags()
+
+	versionMessage := fmt.Sprintf("Managed tokens libary version %s, build %s\n", version, buildTimestamp)
 	if viper.GetBool("version") {
-		fmt.Printf("Managed tokens libary version %s, build %s\n", version, buildTimestamp)
+		fmt.Println(versionMessage)
 		return errExitOK
 	}
+	setupLogger.Info(versionMessage)
 
 	if err := initConfig(); err != nil {
 		fmt.Println("Fatal error setting up configuration.  Exiting now")
@@ -152,11 +156,11 @@ func setup() error {
 	initLogs()
 	initServices()
 	if err := initTimeouts(); err != nil {
-		log.WithField("executable", currentExecutable).Error("Fatal error setting up timeouts")
+		setupLogger.Error("Fatal error setting up timeouts")
 		return err
 	}
 	if err := initMetrics(); err != nil {
-		log.WithField("executable", currentExecutable).Error("Error setting up metrics")
+		setupLogger.Error("Error setting up metrics. Will still continue")
 	}
 	return nil
 }


### PR DESCRIPTION
I figured it'd be easier for debugging if we always logged the version of the managed tokens library at the beginning of each run.