### PR TITLE
Changed testUtils function name SlicesHaveSameElementsOrdered to SlicesHaveSameElementsOrderedType

### DIFF
--- a/cmd/refresh-uids-from-ferry/utils_test.go
+++ b/cmd/refresh-uids-from-ferry/utils_test.go
@@ -66,7 +66,7 @@ func TestGetAllAccountsFromConfig(t *testing.T) {
 	// Assert the expected results
 	expected := []string{"account1", "account2", "account3"}
 	assert.Equal(t, len(expected), len(accounts))
-	assert.True(t, testUtils.SlicesHaveSameElementsOrdered(accounts, expected))
+	assert.True(t, testUtils.SlicesHaveSameElementsOrderedType(accounts, expected))
 }
 
 func TestGetDevEnvironmentLabel(t *testing.T) {

--- a/cmd/token-push/main_test.go
+++ b/cmd/token-push/main_test.go
@@ -126,7 +126,7 @@ func TestInitServices(t *testing.T) {
 				for _, s := range services {
 					results = append(results, s.Name())
 				}
-				if !testUtils.SlicesHaveSameElementsOrdered[string](results, test.expectedServiceNames) {
+				if !testUtils.SlicesHaveSameElementsOrderedType[string](results, test.expectedServiceNames) {
 					t.Errorf("Didn't get expected service names from initServices.  Expected %v, got %v.", test.expectedServiceNames, results)
 				}
 			},

--- a/internal/cmdUtils/cmdUtils_test.go
+++ b/internal/cmdUtils/cmdUtils_test.go
@@ -375,7 +375,7 @@ func TestGetScheddsAndColllectorHostFromConfigurationOverride(t *testing.T) {
 				_, schedds, _ := GetScheddsAndCollectorHostFromConfiguration(ctx, serviceConfigPath)
 				viper.Reset()
 
-				if !testUtils.SlicesHaveSameElementsOrdered[string](test.expectedSchedds, schedds) {
+				if !testUtils.SlicesHaveSameElementsOrderedType[string](test.expectedSchedds, schedds) {
 					t.Errorf("Returned schedd slices are not the same.  Expected %v, got %v", test.expectedSchedds, schedds)
 
 				}

--- a/internal/cmdUtils/scheddCollection_test.go
+++ b/internal/cmdUtils/scheddCollection_test.go
@@ -25,7 +25,7 @@ func TestStoreSchedds(t *testing.T) {
 	expectedSchedds := []string{"schedd1", "schedd2", "schedd3"}
 	s := newScheddCollection()
 	s.storeSchedds(expectedSchedds)
-	if !testUtils.SlicesHaveSameElementsOrdered[string](s.schedds, expectedSchedds) {
+	if !testUtils.SlicesHaveSameElementsOrderedType[string](s.schedds, expectedSchedds) {
 		t.Errorf("Wrong elements stored.  Expected %v, got %v", expectedSchedds, s.schedds)
 	}
 }
@@ -35,7 +35,7 @@ func TestGetSchedds(t *testing.T) {
 	s := newScheddCollection()
 	s.schedds = append(s.schedds, expectedSchedds...)
 	result := s.getSchedds()
-	if !testUtils.SlicesHaveSameElementsOrdered[string](result, expectedSchedds) {
+	if !testUtils.SlicesHaveSameElementsOrderedType[string](result, expectedSchedds) {
 		t.Errorf("Wrong elements stored.  Expected %v, got %v", expectedSchedds, result)
 	}
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -434,7 +434,7 @@ func checkSchema(m *ManagedTokensDatabase) error {
 			}
 		}
 	}
-	if !testUtils.SlicesHaveSameElementsOrdered[string](schemaRows, migrationsSql) {
+	if !testUtils.SlicesHaveSameElementsOrderedType[string](schemaRows, migrationsSql) {
 		return fmt.Errorf(
 			"Schema for database does not match expected schema.  Expected %s, got %s.",
 			migrationsSql,

--- a/internal/db/notificationsDb_test.go
+++ b/internal/db/notificationsDb_test.go
@@ -73,7 +73,7 @@ func TestGetAllServices(t *testing.T) {
 				if err != nil {
 					t.Errorf("Failure to obtain services for test %s: %s", test.description, err)
 				}
-				if !testUtils.SlicesHaveSameElementsOrdered[string](services, test.expectedData) {
+				if !testUtils.SlicesHaveSameElementsOrderedType[string](services, test.expectedData) {
 					t.Errorf("Retrieved data and expected data do not match.  Expected %v, got %v", test.expectedData, services)
 				}
 			},
@@ -124,7 +124,7 @@ func TestGetAllNodes(t *testing.T) {
 				if err != nil {
 					t.Errorf("Failure to obtain nodes for test %s: %s", test.description, err)
 				}
-				if !testUtils.SlicesHaveSameElementsOrdered[string](nodes, test.expectedData) {
+				if !testUtils.SlicesHaveSameElementsOrderedType[string](nodes, test.expectedData) {
 					t.Errorf("Retrieved data and expected data do not match.  Expected %v, got %v", test.expectedData, nodes)
 				}
 			},
@@ -194,7 +194,7 @@ func TestGetNamedDimensionStringValues(t *testing.T) {
 				if !errors.Is(err, test.expectedErr) {
 					t.Errorf("Got wrong error.  Expected %s, got %s", test.expectedErr, err)
 				}
-				if err == nil && !testUtils.SlicesHaveSameElementsOrdered[string](data, test.expectedData) {
+				if err == nil && !testUtils.SlicesHaveSameElementsOrderedType[string](data, test.expectedData) {
 					t.Errorf("Retrieved data and expected data do not match.  Expected %v, got %v", test.expectedData, data)
 				}
 			},
@@ -660,7 +660,7 @@ func TestUpdateServices(t *testing.T) {
 					}
 					retrievedData = append(retrievedData, datum)
 				}
-				if !testUtils.SlicesHaveSameElementsOrdered[string](retrievedData, test.expectedData) {
+				if !testUtils.SlicesHaveSameElementsOrderedType[string](retrievedData, test.expectedData) {
 					t.Errorf("Retrieved data and expected data do not match.  Expected %v, got %v", test.expectedData, retrievedData)
 				}
 			},
@@ -744,7 +744,7 @@ func TestUpdateNodes(t *testing.T) {
 					}
 					retrievedData = append(retrievedData, datum)
 				}
-				if !testUtils.SlicesHaveSameElementsOrdered[string](retrievedData, test.expectedData) {
+				if !testUtils.SlicesHaveSameElementsOrderedType[string](retrievedData, test.expectedData) {
 					t.Errorf("Retrieved data and expected data do not match.  Expected %v, got %v", test.expectedData, retrievedData)
 				}
 			},

--- a/internal/testUtils/testUtils.go
+++ b/internal/testUtils/testUtils.go
@@ -53,7 +53,7 @@ func SlicesHaveSameElements[C comparable](a, b []C) bool {
 // SlicesHaveSameElements compares two slices of comparable and cmp.Ordered type to make
 // sure that they have the same elements.  The ordering of those elements does not matter.
 // This is just a quicker way to test equality of the elements of slices if the types allow.
-func SlicesHaveSameElementsOrdered[C interface {
+func SlicesHaveSameElementsOrderedType[C interface {
 	comparable
 	cmp.Ordered
 }](a, b []C) bool {

--- a/internal/testUtils/testUtils_test.go
+++ b/internal/testUtils/testUtils_test.go
@@ -172,7 +172,7 @@ func TestSlicesHaveSameElementsIntOrdered(t *testing.T) {
 		t.Run(
 			test.description,
 			func(t *testing.T) {
-				result := SlicesHaveSameElementsOrdered[int](test.slice1, test.slice2)
+				result := SlicesHaveSameElementsOrderedType[int](test.slice1, test.slice2)
 				if result != test.expectedResult {
 					t.Errorf("Got wrong result.  Expected %t, got %t", test.expectedResult, result)
 				}
@@ -226,7 +226,7 @@ func TestSlicesHaveSameElementsStringOrdered(t *testing.T) {
 		t.Run(
 			test.description,
 			func(t *testing.T) {
-				result := SlicesHaveSameElementsOrdered[string](test.slice1, test.slice2)
+				result := SlicesHaveSameElementsOrderedType[string](test.slice1, test.slice2)
 				if result != test.expectedResult {
 					t.Errorf("Got wrong result.  Expected %t, got %t", test.expectedResult, result)
 				}
@@ -235,16 +235,16 @@ func TestSlicesHaveSameElementsStringOrdered(t *testing.T) {
 	}
 }
 
-// Note that on these examples, the SlicesHaveSameElementsOrdered func is about 30-50
+// Note that on these examples, the SlicesHaveSameElementsOrderedType func is about 30-50
 // times faster than SlicesHaveSameElements as measured by these benchmarks, so the
 // Ordered func should be used where possible
-func BenchmarkSlicesHaveSameElementsOrderedString(b *testing.B) {
+func BenchmarkSlicesHaveSameElementsOrderedTypeString(b *testing.B) {
 	slice1 := []string{"foo", "bar", "baz"}
 	slice2 := []string{"baz", "foo", "bar"}
 
 	// Run the slice tester on strings
 	for n := 0; n < b.N; n++ {
-		SlicesHaveSameElementsOrdered[string](slice1, slice2)
+		SlicesHaveSameElementsOrderedType[string](slice1, slice2)
 	}
 }
 
@@ -257,13 +257,13 @@ func BenchmarkSlicesHaveSameElementsString(b *testing.B) {
 		SlicesHaveSameElements(slice1, slice2)
 	}
 }
-func BenchmarkSlicesHaveSameElementsOrderedInt(b *testing.B) {
+func BenchmarkSlicesHaveSameElementsOrderedTypeInt(b *testing.B) {
 	slice1 := []int{1, 2, 3}
 	slice2 := []int{2, 1, 3}
 
 	// Run the slice tester on strings
 	for n := 0; n < b.N; n++ {
-		SlicesHaveSameElementsOrdered[int](slice1, slice2)
+		SlicesHaveSameElementsOrderedType[int](slice1, slice2)
 	}
 }
 
@@ -290,12 +290,12 @@ func BenchmarkSlicesHaveSameElementsIntFail(b *testing.B) {
 	}
 }
 
-func BenchmarkSlicesHaveSameElementsOrderedIntFail(b *testing.B) {
+func BenchmarkSlicesHaveSameElementsOrderedTypeIntFail(b *testing.B) {
 	slice1 := []int{1, 2, 3, 3}
 	slice2 := []int{2, 1, 3}
 
 	// Run the slice tester on strings
 	for n := 0; n < b.N; n++ {
-		SlicesHaveSameElementsOrdered(slice1, slice2)
+		SlicesHaveSameElementsOrderedType(slice1, slice2)
 	}
 }

--- a/internal/worker/config_test.go
+++ b/internal/worker/config_test.go
@@ -141,7 +141,7 @@ func TestRegisterUnpingableNode(t *testing.T) {
 			return true
 		})
 
-		if !testUtils.SlicesHaveSameElementsOrdered[string](test.expectedNodes, finalNodes) {
+		if !testUtils.SlicesHaveSameElementsOrderedType[string](test.expectedNodes, finalNodes) {
 			t.Errorf("Expected registered unpingable nodes is different than results.  Expected %v, got %v", test.expectedNodes, finalNodes)
 		}
 	}


### PR DESCRIPTION
Changed `testUtils` function name `SlicesHaveSameElementsOrdered` to `SlicesHaveSameElementsOrderedType` to indicate that the slices aren't in order, but their elements satisfy the `cmp.Ordered` interface.  

Just a small code cleanup commit.  All unit tests pass.