### PR TITLE
Pre commit refactor

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -4,6 +4,7 @@
 name: Go build/test
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
   pull_request:

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  CI: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -58,4 +61,4 @@ jobs:
       run: mkdir -p /home/runner/.managed-tokens; touch /home/runner/.managed-tokens/managedTokens.yml
 
     - name: Test
-      run: go test -v ./... -skip "(TestGetSecCredentialGettokenOptsFromCondor)"
+      run: go test -v ./...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,7 @@ repos:
     - id: go-fmt
     - id: go-mod-tidy
     - id: go-mod-vendor
+ci:
+  autofix_prs: false
+  autoupdate_branch: 'pre-commit.ci-autoupdate'
+  autoupdate_schedule: 'quarterly'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
+    -   id: check-added-large-files
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
@@ -10,7 +11,5 @@ repos:
   rev: v0.5.0
   hooks:
     - id: go-fmt
-    - id: go-unit-tests
-    # - id: go-build
     - id: go-mod-tidy
     - id: go-mod-vendor

--- a/internal/cmdUtils/cmdUtils_test.go
+++ b/internal/cmdUtils/cmdUtils_test.go
@@ -534,8 +534,8 @@ func TestGetVaultServer(t *testing.T) {
 }
 
 func TestGetSecCredentialGettokenOptsFromCondor(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skipf("Skipping test in CI environment.  CI=%s", os.Getenv("CI"))
+	if val, ok := os.LookupEnv("CI"); ok && val != "" {
+		t.Skipf("Skipping condor-dependent test in CI environment.  CI=%s", val)
 	}
 
 	// Override condor config file to test


### PR DESCRIPTION
A few cleanup actions of the pre-commit/CI workflows:

1. We no longer run test suite in pre-commit.  Since we have the tests in a github action, there's no reason to do that in the pre-commit as well. Devs should make sure to run the test suite before opening a PR, in the few cases (condor-specific tests) where tests get skipped in the CI environment.
2. Add pre-commit.ci support so that our pre-commit checks are run as a part of every PR.
3. Some minor test refactoring to support the CI environment check mentioned in (1)

