### PR TITLE
Add retry sleep

### DIFF
--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -387,10 +387,15 @@ func run(ctx context.Context) error {
 
 			// Worker-specific config to be passed to the worker.Config constructor
 			getKerberosTicketsRetries := getWorkerConfigInt("getKerberosTickets", "numRetries")
+			getKerberosTicketsRetrySleep := getWorkerConfigTimeDuration("getKerberosTickets", "retrySleep")
 			storeAndGetTokenRetries := getWorkerConfigInt("storeAndGetToken", "numRetries")
+			storeAndGetTokenRetrySleep := getWorkerConfigTimeDuration("storeAndGetToken", "retrySleep")
 			storeAndGetTokenInteractiveRetries := getWorkerConfigInt("storeAndGetTokenInteractive", "numRetries")
+			storeAndGetTokenInteractiveRetrySleep := getWorkerConfigTimeDuration("storeAndGetTokenInteractive", "retrySleep")
 			pingAggregatorRetries := getWorkerConfigInt("pingAggregator", "numRetries")
+			pingAggregatorRetrySleep := getWorkerConfigTimeDuration("pingAggregator", "retrySleep")
 			pushTokensRetries := getWorkerConfigInt("pushTokens", "numRetries")
+			pushTokensRetrySleep := getWorkerConfigTimeDuration("pushTokens", "retrySleep")
 
 			c, err := worker.NewConfig(
 				s,
@@ -407,11 +412,22 @@ func run(ctx context.Context) error {
 				worker.SetDesiredUID(uid),
 				worker.SetNodes(viper.GetStringSlice(serviceConfigPath+".destinationNodes")),
 				worker.SetAccount(viper.GetString(serviceConfigPath+".account")),
-				worker.SetWorkerRetryValue(worker.GetKerberosTicketsWorkerType, uint(getKerberosTicketsRetries)),
-				worker.SetWorkerRetryValue(worker.StoreAndGetTokenWorkerType, uint(storeAndGetTokenRetries)),
-				worker.SetWorkerRetryValue(worker.StoreAndGetTokenInteractiveWorkerType, uint(storeAndGetTokenInteractiveRetries)),
-				worker.SetWorkerRetryValue(worker.PingAggregatorWorkerType, uint(pingAggregatorRetries)),
-				worker.SetWorkerRetryValue(worker.PushTokensWorkerType, uint(pushTokensRetries)),
+
+				worker.SetWorkerNumRetriesValue(worker.GetKerberosTicketsWorkerType, uint(getKerberosTicketsRetries)),
+				worker.SetWorkerRetrySleepValue(worker.GetKerberosTicketsWorkerType, getKerberosTicketsRetrySleep),
+
+				worker.SetWorkerNumRetriesValue(worker.StoreAndGetTokenWorkerType, uint(storeAndGetTokenRetries)),
+				worker.SetWorkerRetrySleepValue(worker.StoreAndGetTokenWorkerType, storeAndGetTokenRetrySleep),
+
+				worker.SetWorkerNumRetriesValue(worker.StoreAndGetTokenInteractiveWorkerType, uint(storeAndGetTokenInteractiveRetries)),
+				worker.SetWorkerRetrySleepValue(worker.StoreAndGetTokenInteractiveWorkerType, storeAndGetTokenInteractiveRetrySleep),
+
+				worker.SetWorkerNumRetriesValue(worker.PingAggregatorWorkerType, uint(pingAggregatorRetries)),
+				worker.SetWorkerRetrySleepValue(worker.PingAggregatorWorkerType, pingAggregatorRetrySleep),
+
+				worker.SetWorkerNumRetriesValue(worker.PushTokensWorkerType, uint(pushTokensRetries)),
+				worker.SetWorkerRetrySleepValue(worker.PushTokensWorkerType, pushTokensRetrySleep),
+
 				worker.SetSupportedExtrasKeyValue(worker.DefaultRoleFileDestinationTemplate, defaultRoleFileDestinationTemplate),
 				worker.SetSupportedExtrasKeyValue(worker.FileCopierOptions, fileCopierOptions),
 				worker.SetSupportedExtrasKeyValue(worker.PingOptions, extraPingOpts),

--- a/cmd/token-push/workerType.go
+++ b/cmd/token-push/workerType.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 
@@ -36,9 +37,7 @@ func getWorkerConfigValue(workerType, key string) any {
 	if !isValidWorkerTypeString(workerType) {
 		return nil
 	}
-
 	workerConfigPath := "workerType." + workerType + "." + key
-
 	return viper.Get(workerConfigPath)
 }
 
@@ -71,6 +70,22 @@ func getWorkerConfigStringSlice(workerType, key string) []string {
 		return v
 	}
 	return empty
+}
+
+// getWorkerConfigTimeDuration retrieves the configuration value for the given worker type and key,
+// and returns it as a time.Duration. If the configuration value cannot be parsed into a time.Duration,
+// 0 is returned
+func getWorkerConfigTimeDuration(workerType, key string) time.Duration {
+	val := getWorkerConfigValue(workerType, key)
+	v, ok := val.(string)
+	if !ok {
+		return 0
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0
+	}
+	return d
 }
 
 // isValidWorkerTypeString checks if the given string is equal to the string representation

--- a/cmd/token-push/workerType_test.go
+++ b/cmd/token-push/workerType_test.go
@@ -18,6 +18,7 @@ package main
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -133,9 +134,6 @@ func TestGetWorkerConfigValue(t *testing.T) {
 
 			// Check the result
 			assert.Equal(t, tc.expected, result)
-			// if !reflect.DeepEqual(result, tc.expected) {
-			// 	t.Errorf("Unexpected result. Expected: %v, Got: %v", tc.expected, result)
-			// }
 		})
 	}
 }
@@ -174,5 +172,46 @@ func TestIsValidWorkerTypeString(t *testing.T) {
 	for _, test := range tests {
 		result := isValidWorkerTypeString(test.input)
 		assert.Equal(t, test.expected, result)
+	}
+}
+
+func TestGetWorkerConfigTimeDuration(t *testing.T) {
+	workerType := "getKerberosTickets"
+	key := "myKey"
+
+	type testCase struct {
+		description   string
+		testValue     any
+		expectedValue time.Duration
+	}
+
+	testCases := []testCase{
+		{
+			description:   "Valid duration string",
+			testValue:     "5m",
+			expectedValue: 5 * time.Minute,
+		},
+		{
+			description:   "Invalid duration string",
+			testValue:     "invalidDuration",
+			expectedValue: time.Duration(0),
+		},
+		{
+			description:   "Non-string value",
+			testValue:     12345,
+			expectedValue: time.Duration(0),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			// Set up the configuration
+			viper.Reset()
+			defer viper.Reset()
+			viper.Set("workerType."+workerType+"."+key, tc.testValue)
+
+			result := getWorkerConfigTimeDuration(workerType, key)
+			assert.Equal(t, tc.expectedValue, result)
+		})
 	}
 }

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -128,6 +128,7 @@ func backupConfig(c1 *Config) *Config {
 		VaultServer:                    c1.VaultServer,
 		Extras:                         c1.Extras,
 		CommandEnvironment:             c1.CommandEnvironment,
+		workerSpecificConfig:           c1.workerSpecificConfig,
 		unPingableNodes:                c1.unPingableNodes,
 	}
 	return c2

--- a/internal/worker/config_test.go
+++ b/internal/worker/config_test.go
@@ -208,6 +208,11 @@ func TestBackupConfig(t *testing.T) {
 	}
 	c1.unPingableNodes = &unPingableNodes{sync.Map{}}
 	c1.unPingableNodes.Store("foo", struct{}{})
+	c1.workerSpecificConfig = map[WorkerType]map[workerSpecificConfigOption]any{
+		PushTokensWorkerType: {
+			numRetriesOption: 5,
+		},
+	}
 
 	c2 := backupConfig(c1)
 
@@ -224,6 +229,7 @@ func TestBackupConfig(t *testing.T) {
 
 	assert.Equal(t, c1.Extras, c2.Extras)
 	assert.Equal(t, c1.unPingableNodes, c2.unPingableNodes)
+	assert.Equal(t, c1.workerSpecificConfig, c2.workerSpecificConfig)
 }
 
 func TestInitializeWorkerSpecificConfigDefaults(t *testing.T) {

--- a/managedTokens.yml
+++ b/managedTokens.yml
@@ -85,14 +85,19 @@ notifications_test:
 workerType:
   getKerberosTickets:
     numRetries: 0
+    retrySleep: "0s"
   storeAndGetToken:
     numRetries: 0
+    retrySleep: "0s"
   storeAndGetTokenInteractive:
     numRetries: 0
+    retrySleep: "0s"
   pingAggregator:
     numRetries: 0
+    retrySleep: "0s"
   pushTokens:
     numRetries: 3
+    retrySleep: "60s"
 
 # Experiment config items
 experiments:


### PR DESCRIPTION
This PR is one to add a configurable sleep between worker retry operations.  I tried to organize the commits by layers, so hopefully it's pretty easy to follow.

1. Added `retrySleepOption` choice value for `workerSpecificConfigOption` type (`internal/worker/workerSpecificConfig.go`), along with setter/getter functions for that option.  This allows importing packages to set the `retrySleepOption` setting in a `worker.Config` to a value of type `time.Duration` for a specified `worker.WorkerType`, and any caller inside the `worker` package to retrieve the value type-safely.
2. As the second part of (1) implies, the next change is in `internal/worker/pushTokensWorker.go` to retrieve the `retrySleepOption`  value from the `worker.Config` it is currently using.  We then use that value and sleep between retries.
3. In `cmd/token-push/workerType.go`, created a function to retrieve a value from the service configuration (`managedTokens.yml`, for example), and safely return it as a `time.Duration`, if possible.
4. In `cmd/token-push/main.go`, use (3) to retrieve the worker-specific `retrySleep` values from the service configuration as `time.Duration` values, and set the various `worker.Config` objects' `retrySleepOption` settings using the new setter function mentioned in (1)

There is also a bugfix in `internal/worker/config.go`, and tests accompanying all of the changes mentioned here.
