### PR TITLE
Refactor of pushTokensWorker and reimplementation of retry sleep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
 NAME = managed-tokens
-<<<<<<< HEAD
-VERSION = v0.16.1
-=======
 VERSION = v0.16.2
->>>>>>> a86cf7b (Change version to v0.16.2)
 ROOTDIR = $(shell pwd)
 BUILD = $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 rpmVersion := $(subst v,,$(VERSION))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 NAME = managed-tokens
+<<<<<<< HEAD
 VERSION = v0.16.1
+=======
+VERSION = v0.16.2
+>>>>>>> a86cf7b (Change version to v0.16.2)
 ROOTDIR = $(shell pwd)
 BUILD = $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 rpmVersion := $(subst v,,$(VERSION))

--- a/cmd/token-push/config.go
+++ b/cmd/token-push/config.go
@@ -450,7 +450,7 @@ func parseVaultServerFromEnvSetting(envSetting string) (string, error) {
 	return *vaultServerPtr, nil
 }
 
-func checkRetryTimeout(numRetries uint, retrySleepDuration time.Duration, timeout time.Duration) error {
+func checkRetryTimeout(numRetries int, retrySleepDuration time.Duration, timeout time.Duration) error {
 	if timeout < time.Duration(numRetries)*retrySleepDuration {
 		return fmt.Errorf("timeout (%s) is less than numRetries*retrySleepDuration (%s)", timeout, time.Duration(numRetries)*retrySleepDuration)
 	}

--- a/cmd/token-push/config.go
+++ b/cmd/token-push/config.go
@@ -27,6 +27,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/shlex"
 	log "github.com/sirupsen/logrus"
@@ -447,4 +448,11 @@ func parseVaultServerFromEnvSetting(envSetting string) (string, error) {
 	}
 
 	return *vaultServerPtr, nil
+}
+
+func checkRetryTimeout(numRetries uint, retrySleepDuration time.Duration, timeout time.Duration) error {
+	if timeout < time.Duration(numRetries)*retrySleepDuration {
+		return fmt.Errorf("timeout (%s) is less than numRetries*retrySleepDuration (%s)", timeout, time.Duration(numRetries)*retrySleepDuration)
+	}
+	return nil
 }

--- a/cmd/token-push/config_test.go
+++ b/cmd/token-push/config_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -1161,5 +1162,50 @@ func TestResolveDisableNotifications(t *testing.T) {
 				assert.Equal(t, test.expectedNoServiceNotifications, noServiceNotifications)
 			},
 		)
+	}
+}
+
+func TestCheckRetryTimeout(t *testing.T) {
+	type testCase struct {
+		description        string
+		numRetries         uint
+		retrySleepDuration time.Duration
+		timeout            time.Duration
+		expectedError      bool
+	}
+
+	testCases := []testCase{
+		{
+			description:        "Timeout is greater than numRetries * retrySleepDuration",
+			numRetries:         3,
+			retrySleepDuration: 10 * time.Second,
+			timeout:            40 * time.Second,
+			expectedError:      false,
+		},
+		{
+			description:        "Timeout is equal to numRetries * retrySleepDuration",
+			numRetries:         3,
+			retrySleepDuration: 10 * time.Second,
+			timeout:            30 * time.Second,
+			expectedError:      false,
+		},
+		{
+			description:        "Timeout is less than numRetries * retrySleepDuration",
+			numRetries:         3,
+			retrySleepDuration: 10 * time.Second,
+			timeout:            20 * time.Second,
+			expectedError:      true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			err := checkRetryTimeout(test.numRetries, test.retrySleepDuration, test.timeout)
+			if test.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }

--- a/cmd/token-push/config_test.go
+++ b/cmd/token-push/config_test.go
@@ -1168,7 +1168,7 @@ func TestResolveDisableNotifications(t *testing.T) {
 func TestCheckRetryTimeout(t *testing.T) {
 	type testCase struct {
 		description        string
-		numRetries         uint
+		numRetries         int
 		retrySleepDuration time.Duration
 		timeout            time.Duration
 		expectedError      bool

--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -297,7 +297,7 @@ func run(ctx context.Context) error {
 			return errors.New(msg)
 		}
 		workerRetryMap[retryArg.WorkerType] = workerRetryConfig{
-			numRetries: numRetries,
+			numRetries: uint(numRetries),
 			retrySleep: retrySleep,
 		}
 	}

--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -275,6 +275,33 @@ func run(ctx context.Context) error {
 		}
 	}
 
+	// Worker-specific config that is service-independent to be passed to the worker.Config constructor
+	// Note - this will be made less verbose when #114-115 are done TODO
+	workerRetryMap := make(map[worker.WorkerType]workerRetryConfig)
+
+	_retryArgs := []struct {
+		worker.WorkerType
+		checkTimeout time.Duration
+	}{
+		{worker.GetKerberosTicketsWorkerType, timeouts[timeoutKerberos]},
+		{worker.StoreAndGetTokenWorkerType, timeouts[timeoutVaultStorer]},
+		{worker.StoreAndGetTokenInteractiveWorkerType, timeouts[timeoutVaultStorer]},
+		{worker.PingAggregatorWorkerType, timeouts[timeoutPing]},
+		{worker.PushTokensWorkerType, timeouts[timeoutPush]},
+	}
+	for _, retryArg := range _retryArgs {
+		numRetries, retrySleep, err := getAndCheckRetryInfoFromConfig(retryArg.WorkerType, retryArg.checkTimeout)
+		if err != nil {
+			msg := fmt.Sprintf("invalid timeout %s: %s", workerTypeToConfigString(retryArg.WorkerType), err.Error())
+			tracing.LogErrorWithTrace(span, exeLogger, msg)
+			return errors.New(msg)
+		}
+		workerRetryMap[retryArg.WorkerType] = workerRetryConfig{
+			numRetries: numRetries,
+			retrySleep: retrySleep,
+		}
+	}
+
 	// All the cleanup actions that should run any time run() returns
 	defer func() {
 		// Run cleanup actions
@@ -386,18 +413,6 @@ func run(ctx context.Context) error {
 			extraPingOpts := getPingOptsFromConfig(serviceConfigPath)
 			sshOpts := getSSHOptsFromConfig(serviceConfigPath)
 
-			// Worker-specific config to be passed to the worker.Config constructor
-			getKerberosTicketsRetries := getWorkerConfigInt("getKerberosTickets", "numRetries")
-			getKerberosTicketsRetrySleep := getWorkerConfigTimeDuration("getKerberosTickets", "retrySleep")
-			storeAndGetTokenRetries := getWorkerConfigInt("storeAndGetToken", "numRetries")
-			storeAndGetTokenRetrySleep := getWorkerConfigTimeDuration("storeAndGetToken", "retrySleep")
-			storeAndGetTokenInteractiveRetries := getWorkerConfigInt("storeAndGetTokenInteractive", "numRetries")
-			storeAndGetTokenInteractiveRetrySleep := getWorkerConfigTimeDuration("storeAndGetTokenInteractive", "retrySleep")
-			pingAggregatorRetries := getWorkerConfigInt("pingAggregator", "numRetries")
-			pingAggregatorRetrySleep := getWorkerConfigTimeDuration("pingAggregator", "retrySleep")
-			pushTokensRetries := getWorkerConfigInt("pushTokens", "numRetries")
-			pushTokensRetrySleep := getWorkerConfigTimeDuration("pushTokens", "retrySleep")
-
 			c, err := worker.NewConfig(
 				s,
 				worker.SetCommandEnvironment(
@@ -413,22 +428,7 @@ func run(ctx context.Context) error {
 				worker.SetDesiredUID(uid),
 				worker.SetNodes(viper.GetStringSlice(serviceConfigPath+".destinationNodes")),
 				worker.SetAccount(viper.GetString(serviceConfigPath+".account")),
-
-				worker.SetWorkerNumRetriesValue(worker.GetKerberosTicketsWorkerType, uint(getKerberosTicketsRetries)),
-				worker.SetWorkerRetrySleepValue(worker.GetKerberosTicketsWorkerType, getKerberosTicketsRetrySleep),
-
-				worker.SetWorkerNumRetriesValue(worker.StoreAndGetTokenWorkerType, uint(storeAndGetTokenRetries)),
-				worker.SetWorkerRetrySleepValue(worker.StoreAndGetTokenWorkerType, storeAndGetTokenRetrySleep),
-
-				worker.SetWorkerNumRetriesValue(worker.StoreAndGetTokenInteractiveWorkerType, uint(storeAndGetTokenInteractiveRetries)),
-				worker.SetWorkerRetrySleepValue(worker.StoreAndGetTokenInteractiveWorkerType, storeAndGetTokenInteractiveRetrySleep),
-
-				worker.SetWorkerNumRetriesValue(worker.PingAggregatorWorkerType, uint(pingAggregatorRetries)),
-				worker.SetWorkerRetrySleepValue(worker.PingAggregatorWorkerType, pingAggregatorRetrySleep),
-
-				worker.SetWorkerNumRetriesValue(worker.PushTokensWorkerType, uint(pushTokensRetries)),
-				worker.SetWorkerRetrySleepValue(worker.PushTokensWorkerType, pushTokensRetrySleep),
-
+				setAllWorkerRetryValues(workerRetryMap),
 				worker.SetSupportedExtrasKeyValue(worker.DefaultRoleFileDestinationTemplate, defaultRoleFileDestinationTemplate),
 				worker.SetSupportedExtrasKeyValue(worker.FileCopierOptions, fileCopierOptions),
 				worker.SetSupportedExtrasKeyValue(worker.PingOptions, extraPingOpts),

--- a/cmd/token-push/workerFuncOpts.go
+++ b/cmd/token-push/workerFuncOpts.go
@@ -92,8 +92,8 @@ func setAllWorkerRetryValues(workerRetryMap map[worker.WorkerType]workerRetryCon
 // getAndCheckRetryInfoFromConfig gets the number of retries and the sleep time between retries from the configuration
 // for a particular worker type key in the configuration.  It then checks that the retry timeout is less than the
 // given duration.
-func getAndCheckRetryInfoFromConfig(wt worker.WorkerType, checkTimeout time.Duration) (numRetries uint, retrySleep time.Duration, err error) {
-	numRetries = getWorkerConfigInteger[uint](wt, "numRetries")
+func getAndCheckRetryInfoFromConfig(wt worker.WorkerType, checkTimeout time.Duration) (numRetries int, retrySleep time.Duration, err error) {
+	numRetries = getWorkerConfigInteger[int](wt, "numRetries")
 	retrySleep = getWorkerConfigTimeDuration(wt, "retrySleep")
 	if err := checkRetryTimeout(numRetries, retrySleep, checkTimeout); err != nil {
 		msg := "timeout is less than the time it would take to retry all attempts.  Will stop now"

--- a/cmd/token-push/workerFuncOpts.go
+++ b/cmd/token-push/workerFuncOpts.go
@@ -67,7 +67,7 @@ func getDesiredUIDByOverrideOrLookup(ctx context.Context, serviceConfigPath stri
 // getVaultTokenStoreHoldoffFuncOpt examines the passed-in service to determine whether to
 // return a NOOP func, or if the service is a experimentOverriddenService,
 // a func(*worker.Config) that sets the vault token store holdoff for the passed in Config
-func getVaultTokenStoreHoldoffFuncOpt(s service.Service) func(*worker.Config) error {
+func getVaultTokenStoreHoldoffFuncOpt(s service.Service) worker.ConfigOption {
 	if _, ok := s.(*experimentOverriddenService); ok {
 		return worker.SetVaultTokenStoreHoldoff()
 	}
@@ -79,7 +79,7 @@ type workerRetryConfig struct {
 	retrySleep time.Duration
 }
 
-func setAllWorkerRetryValues(workerRetryMap map[worker.WorkerType]workerRetryConfig) func(*worker.Config) error {
+func setAllWorkerRetryValues(workerRetryMap map[worker.WorkerType]workerRetryConfig) worker.ConfigOption {
 	return func(c *worker.Config) error {
 		for wt, wr := range workerRetryMap {
 			worker.SetWorkerNumRetriesValue(wt, wr.numRetries)(c)

--- a/cmd/token-push/workerFuncOpts_test.go
+++ b/cmd/token-push/workerFuncOpts_test.go
@@ -15,7 +15,7 @@ func TestGetAndCheckRetryInfoFromConfig(t *testing.T) {
 		name          string
 		workerType    worker.WorkerType
 		checkTimeout  time.Duration
-		numRetries    uint
+		numRetries    int
 		retrySleep    time.Duration
 		expectedError error
 	}{
@@ -47,7 +47,7 @@ func TestGetAndCheckRetryInfoFromConfig(t *testing.T) {
 			numRetries, retrySleep, err := getAndCheckRetryInfoFromConfig(tt.workerType, tt.checkTimeout)
 			if tt.expectedError != nil {
 				assert.EqualError(t, err, tt.expectedError.Error())
-				assert.Equal(t, uint(0), numRetries)
+				assert.Equal(t, 0, numRetries)
 				assert.Equal(t, time.Duration(0), retrySleep)
 				return
 			}

--- a/cmd/token-push/workerFuncOpts_test.go
+++ b/cmd/token-push/workerFuncOpts_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/fermitools/managed-tokens/internal/worker"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAndCheckRetryInfoFromConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		workerType    worker.WorkerType
+		checkTimeout  time.Duration
+		numRetries    uint
+		retrySleep    time.Duration
+		expectedError error
+	}{
+		{
+			name:          "Valid configuration",
+			workerType:    worker.GetKerberosTicketsWorkerType,
+			checkTimeout:  10 * time.Second,
+			numRetries:    3,
+			retrySleep:    2 * time.Second,
+			expectedError: nil,
+		},
+		{
+			name:          "Invalid configuration - timeout less than retry duration",
+			workerType:    worker.GetKerberosTicketsWorkerType,
+			checkTimeout:  5 * time.Second,
+			numRetries:    3,
+			retrySleep:    2 * time.Second,
+			expectedError: errors.New("timeout is less than the time it would take to retry all attempts.  Will stop now"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			defer viper.Reset()
+			viper.Set("workerType."+workerTypeToConfigString(tt.workerType)+".numRetries", tt.numRetries)
+			viper.Set("workerType."+workerTypeToConfigString(tt.workerType)+".retrySleep", tt.retrySleep.String())
+
+			numRetries, retrySleep, err := getAndCheckRetryInfoFromConfig(tt.workerType, tt.checkTimeout)
+			if tt.expectedError != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+				assert.Equal(t, uint(0), numRetries)
+				assert.Equal(t, time.Duration(0), retrySleep)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.numRetries, numRetries)
+			assert.Equal(t, tt.retrySleep, retrySleep)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/fermitools/managed-tokens
 
-go 1.22
+go 1.22.0
+
+toolchain go1.22.2
 
 require (
 	github.com/cornfeedhobo/pflag v1.1.0
@@ -18,7 +20,8 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.31.0
 	go.opentelemetry.io/otel/sdk v1.31.0
 	go.opentelemetry.io/otel/trace v1.31.0
-	golang.org/x/sync v0.8.0
+	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
+	golang.org/x/sync v0.10.0
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 )
 

--- a/go.sum
+++ b/go.sum
@@ -365,6 +365,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 h1:yqrTHse8TCMW1M1ZCP+VAR/l0kKxwaAIqN/il7x4voA=
+golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -448,8 +450,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/packaging/managed-tokens.spec
+++ b/packaging/managed-tokens.spec
@@ -1,5 +1,9 @@
 Name:           managed-tokens
+<<<<<<< HEAD
 Version:        0.16.1
+=======
+Version:        0.16.2
+>>>>>>> a86cf7b (Change version to v0.16.2)
 Release:        1%{?dist}
 Summary:        Utility to obtain Hashicorp vault (service) tokens from service kerberos principals and distribute them to experiment nodes
 

--- a/packaging/managed-tokens.spec
+++ b/packaging/managed-tokens.spec
@@ -1,9 +1,5 @@
 Name:           managed-tokens
-<<<<<<< HEAD
-Version:        0.16.1
-=======
 Version:        0.16.2
->>>>>>> a86cf7b (Change version to v0.16.2)
 Release:        1%{?dist}
 Summary:        Utility to obtain Hashicorp vault (service) tokens from service kerberos principals and distribute them to experiment nodes
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,6 +267,9 @@ go.opentelemetry.io/proto/otlp/trace/v1
 golang.org/x/crypto/curve25519
 golang.org/x/crypto/ed25519
 golang.org/x/crypto/pbkdf2
+# golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
+## explicit; go 1.22.0
+golang.org/x/exp/constraints
 # golang.org/x/net v0.30.0
 ## explicit; go 1.18
 golang.org/x/net/http/httpguts
@@ -275,7 +278,7 @@ golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
-# golang.org/x/sync v0.8.0
+# golang.org/x/sync v0.10.0
 ## explicit; go 1.18
 golang.org/x/sync/errgroup
 # golang.org/x/sys v0.26.0


### PR DESCRIPTION
Closes #116 

## Synopsis

When working on #113, a bug was introduced due to the complex nature of the `pushTokensWorker`. This was patched for `v0.16.2`, but with values hardcoded.  This PR aims to do two things:

1. Refactor pushTokensWorker so that the logic is clearer
2. Reimplement a configurable retrySleep option for workers

The changes in this PR are summarized below in layers.

## Changes

### `internal/worker/pushTokensWorker.go` refactor

This logic was complex because there were nested for-loops meant to iterate through combinations of `worker.Config` objects, destination nodes, and the various files to be pushed.  To further complicate things, concurrency was handled within those nested loops and anonymous funcs, making the code tougher to grok.

Instead, we introduce an unexported struct, `pushTokensConfig`, that will contain the information needed to push files to destination nodes.  A new helper function `getPushTokensValuesFromConfig` parses the passed in `worker.Config` object and generates the various `pushTokensConfig` objects, one per file that needs to be transferred (so three per service). 

The function `PushTokensWorker` uses a [`errgroup.Group`](https://pkg.go.dev/golang.org/x/sync/errgroup#Group) to concurrently push the tokens.  Since any token push failure counts as the push having failed, `errgroup.Group`'s error-handling behavior works very well for this case.

The `errgroup.Group` will launch goroutines (`g.Go(....)`) for each `pushTokensConfig` item. Each of these configs items will have their elements fed into the function `pushToNode`, similar to before.  Retries and sleeping are handled in `pushToNode`, which makes implementing the retry much easier.

If there is an error, we send the notification only once (see the `nodesNotifyOnce` variable, which stores a map of node to a [sync.Once](https://pkg.go.dev/sync#Once) object).

Compiling successes/failures is much like before.

### `cmd/token-push` changes to make numRetries and retrySleep configurable

1. `cmd/token-push/workerType.go`:
  a. We now require that all configuration for worker-specific items be tied to the specific `worker.WorkerType`.  The transformation from `worker.WorkerType` to valid configuration string is given in the function `workerTypeToConfigString`.  All of the `getWorkerConfig...` funcs are updated to accept a `worker.WorkerType` rather than a random string.  
  b. I also implemented a generic `getWorkerConfigInteger` func (eventually to get the `numRetries` value), which supports getting/returning any type that fits the (`constraints.Integer`)[https://pkg.go.dev/golang.org/x/exp@v0.0.0-20250106191152-7588d65b2ba8/constraints#Integer] constraint.
2. `cmd/token-push/workerFuncOpts.go`:
  a. Introduce an internal `workerRetryConfig` type that holds a `numRetries` uint and a `retrySleep` `time.Duration` value. 
  b. At @cathulhu 's suggestion, Introduce a function `setAllWorkerRetryValues` to dynamically set all of the worker-specific `numRetries` and `retrySleep` values
3. `cmd/token-push/config.go`: `getAndCheckRetryInfoFromConfig` is simply a check that the combined duration of configured retries and sleeps doesn't exceed the configured timeout for a given worker.
4. `cmd/token-push/main.go`. Combines points 1-3 above to get `numRetries` and `retrySleep` values from the configuration for each workerType, check them, and then load them into the `worker.Config` objects that will eventually be used to push tokens.

### Other changes

1. Tests to support all of the above
2. Changes to `go.mod`, `go.sum`, and `vendor/` are simply automated Go tooling changes required by the above.
3. I forgot to commit changes to the Makefile/spec file, so that's here as well.