### PR TITLE
Export worker.WorkerSpecificConfigOption to reduce the number of exported setters/getters

### DIFF
--- a/cmd/token-push/main.go
+++ b/cmd/token-push/main.go
@@ -388,7 +388,6 @@ func run(ctx context.Context) error {
 			keytabPath := getKeytabFromConfiguration(serviceConfigPath)
 			defaultRoleFileDestinationTemplate := getDefaultRoleFileDestinationTemplate(serviceConfigPath)
 			serviceCreddVaultTokenPathRoot := getServiceCreddVaultTokenPathRoot(serviceConfigPath)
-			vaultTokenStoreHoldoffFunc := getVaultTokenStoreHoldoffFuncOpt(s)
 			fileCopierOptions := getFileCopierOptionsFromConfig(serviceConfigPath)
 			extraPingOpts := getPingOptsFromConfig(serviceConfigPath)
 			sshOpts := getSSHOptsFromConfig(serviceConfigPath)
@@ -413,7 +412,6 @@ func run(ctx context.Context) error {
 				worker.SetSupportedExtrasKeyValue(worker.FileCopierOptions, fileCopierOptions),
 				worker.SetSupportedExtrasKeyValue(worker.PingOptions, extraPingOpts),
 				worker.SetSupportedExtrasKeyValue(worker.SSHOptions, sshOpts),
-				vaultTokenStoreHoldoffFunc,
 			)
 			if err != nil {
 				tracing.LogErrorWithTrace(span, funcLogger, "Could not create config for service")

--- a/cmd/token-push/workerFuncOpts.go
+++ b/cmd/token-push/workerFuncOpts.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -54,7 +55,7 @@ func getDesiredUIDByOverrideOrLookup(ctx context.Context, serviceConfigPath stri
 	uid, err := database.GetUIDByUsername(ctx, username)
 	if err != nil {
 		log.Error("Could not get UID by username")
-		return 0, err
+		return 0, fmt.Errorf("could not get UID by username: %w", err)
 	}
 	log.WithFields(log.Fields{
 		"username": username,

--- a/cmd/token-push/workerFuncOpts.go
+++ b/cmd/token-push/workerFuncOpts.go
@@ -82,22 +82,11 @@ type workerRetryConfig struct {
 func setAllWorkerRetryValues(workerRetryMap map[worker.WorkerType]workerRetryConfig) worker.ConfigOption {
 	return func(c *worker.Config) error {
 		for wt, wr := range workerRetryMap {
-			worker.SetWorkerNumRetriesValue(wt, wr.numRetries)(c)
-			worker.SetWorkerRetrySleepValue(wt, wr.retrySleep)(c)
+			// TODO When we upgrade to Go 1.24, maybe replace the below with an iterator that dynamically generates the
+			// retry-specific worker-specific config options that are supported
+			worker.SetWorkerSpecificConfigOption(wt, worker.NumRetriesOption, wr.numRetries)(c)
+			worker.SetWorkerSpecificConfigOption(wt, worker.RetrySleepOption, wr.retrySleep)(c)
 		}
 		return nil
 	}
-}
-
-// getAndCheckRetryInfoFromConfig gets the number of retries and the sleep time between retries from the configuration
-// for a particular worker type key in the configuration.  It then checks that the retry timeout is less than the
-// given duration.
-func getAndCheckRetryInfoFromConfig(wt worker.WorkerType, checkTimeout time.Duration) (numRetries int, retrySleep time.Duration, err error) {
-	numRetries = getWorkerConfigInteger[int](wt, "numRetries")
-	retrySleep = getWorkerConfigTimeDuration(wt, "retrySleep")
-	if err := checkRetryTimeout(numRetries, retrySleep, checkTimeout); err != nil {
-		msg := "timeout is less than the time it would take to retry all attempts.  Will stop now"
-		return 0, 0, errors.New(msg)
-	}
-	return numRetries, retrySleep, nil
 }

--- a/cmd/token-push/workerFuncOpts.go
+++ b/cmd/token-push/workerFuncOpts.go
@@ -26,7 +26,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/fermitools/managed-tokens/internal/db"
-	"github.com/fermitools/managed-tokens/internal/service"
 	"github.com/fermitools/managed-tokens/internal/worker"
 )
 
@@ -62,16 +61,6 @@ func getDesiredUIDByOverrideOrLookup(ctx context.Context, serviceConfigPath stri
 		"uid":      uid,
 	}).Debug("Got UID")
 	return uint32(uid), nil
-}
-
-// getVaultTokenStoreHoldoffFuncOpt examines the passed-in service to determine whether to
-// return a NOOP func, or if the service is a experimentOverriddenService,
-// a func(*worker.Config) that sets the vault token store holdoff for the passed in Config
-func getVaultTokenStoreHoldoffFuncOpt(s service.Service) worker.ConfigOption {
-	if _, ok := s.(*experimentOverriddenService); ok {
-		return worker.SetVaultTokenStoreHoldoff()
-	}
-	return func(c *worker.Config) error { return nil } // NOOP
 }
 
 type workerRetryConfig struct {

--- a/cmd/token-push/workerFuncOpts_test.go
+++ b/cmd/token-push/workerFuncOpts_test.go
@@ -1,11 +1,111 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fermitools/managed-tokens/internal/db"
 )
 
 func TestGetDesiredUIDByOverrideOrLookup(t *testing.T) {
+	serviceConfigPath = "service_path"
+	tempDir := t.TempDir()
 
+	type testCase struct {
+		description       string
+		viperSetupFunc    func()
+		databaseSetupFunc func() *db.ManagedTokensDatabase
+		expectedUID       uint32
+		expectedError     error
+	}
+
+	testCases := []testCase{
+		{
+			description: "Valid uid override",
+			viperSetupFunc: func() {
+				viper.Set(serviceConfigPath+".desiredUIDOverride", 123)
+			},
+			databaseSetupFunc: func() *db.ManagedTokensDatabase { return nil },
+			expectedUID:       123,
+			expectedError:     nil,
+		},
+		{
+			description:       "No valid database",
+			viperSetupFunc:    func() {},
+			databaseSetupFunc: func() *db.ManagedTokensDatabase { return nil },
+			expectedUID:       0,
+			expectedError:     errors.New("no valid database to read UID from"),
+		},
+		{
+			description: "Get UID from DB, error",
+			viperSetupFunc: func() {
+				viper.Set(serviceConfigPath+".account", "testaccount")
+			},
+			databaseSetupFunc: func() *db.ManagedTokensDatabase {
+				filename := tempDir + "/test_nodata.db"
+				d, err := db.OpenOrCreateDatabase(filename)
+				if err != nil {
+					panic("Could not open test database" + err.Error())
+				}
+				return d
+			},
+			expectedUID:   0,
+			expectedError: errors.New("could not get UID by username: sql: no rows in result set"),
+		},
+		{
+			description: "Get UID from DB, success",
+			viperSetupFunc: func() {
+				viper.Set(serviceConfigPath+".account", "testaccount")
+			},
+			databaseSetupFunc: func() *db.ManagedTokensDatabase {
+				filename := tempDir + "/test_populated.db"
+				d, err := db.OpenOrCreateDatabase(filename)
+				if err != nil {
+					panic("Could not open test database" + err.Error())
+				}
+				f := fakeFerryUIDDatum{"testaccount", 123}
+				err = d.InsertUidsIntoTableFromFERRY(context.Background(), []db.FerryUIDDatum{f})
+				if err != nil {
+					panic("Could not insert test data into database" + err.Error())
+				}
+				return d
+			},
+			expectedUID:   123,
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			defer viper.Reset()
+			tc.viperSetupFunc()
+			uid, err := getDesiredUIDByOverrideOrLookup(context.Background(), serviceConfigPath, tc.databaseSetupFunc())
+
+			assert.Equal(t, tc.expectedUID, uid)
+			if tc.expectedError != nil {
+				assert.EqualError(t, err, tc.expectedError.Error())
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
 }
 
-func TestGetVaultTokenStoreHoldoffFuncOpt(t *testing.T) {}
+type fakeFerryUIDDatum struct {
+	username string
+	uid      int
+}
+
+func (f fakeFerryUIDDatum) Username() string {
+	return f.username
+}
+func (f fakeFerryUIDDatum) Uid() int {
+	return f.uid
+}
+func (f fakeFerryUIDDatum) String() string {
+	return "NOT IMPLEMENTED"
+}

--- a/cmd/token-push/workerFuncOpts_test.go
+++ b/cmd/token-push/workerFuncOpts_test.go
@@ -1,60 +1,11 @@
 package main
 
 import (
-	"errors"
 	"testing"
-	"time"
-
-	"github.com/fermitools/managed-tokens/internal/worker"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestGetAndCheckRetryInfoFromConfig(t *testing.T) {
-	tests := []struct {
-		name          string
-		workerType    worker.WorkerType
-		checkTimeout  time.Duration
-		numRetries    int
-		retrySleep    time.Duration
-		expectedError error
-	}{
-		{
-			name:          "Valid configuration",
-			workerType:    worker.GetKerberosTicketsWorkerType,
-			checkTimeout:  10 * time.Second,
-			numRetries:    3,
-			retrySleep:    2 * time.Second,
-			expectedError: nil,
-		},
-		{
-			name:          "Invalid configuration - timeout less than retry duration",
-			workerType:    worker.GetKerberosTicketsWorkerType,
-			checkTimeout:  5 * time.Second,
-			numRetries:    3,
-			retrySleep:    2 * time.Second,
-			expectedError: errors.New("timeout is less than the time it would take to retry all attempts.  Will stop now"),
-		},
-	}
+func TestGetDesiredUIDByOverrideOrLookup(t *testing.T) {
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			viper.Reset()
-			defer viper.Reset()
-			viper.Set("workerType."+workerTypeToConfigString(tt.workerType)+".numRetries", tt.numRetries)
-			viper.Set("workerType."+workerTypeToConfigString(tt.workerType)+".retrySleep", tt.retrySleep.String())
-
-			numRetries, retrySleep, err := getAndCheckRetryInfoFromConfig(tt.workerType, tt.checkTimeout)
-			if tt.expectedError != nil {
-				assert.EqualError(t, err, tt.expectedError.Error())
-				assert.Equal(t, 0, numRetries)
-				assert.Equal(t, time.Duration(0), retrySleep)
-				return
-			}
-
-			assert.NoError(t, err)
-			assert.Equal(t, tt.numRetries, numRetries)
-			assert.Equal(t, tt.retrySleep, retrySleep)
-		})
-	}
 }
+
+func TestGetVaultTokenStoreHoldoffFuncOpt(t *testing.T) {}

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	// Then the caller should check ok to make sure it's true before using the value
 	Extras map[supportedExtrasKey]any
 	// workerSpecificConfig is a map of values that are specific to a worker type.  This is useful for setting values that are specific to a worker
-	workerSpecificConfig map[WorkerType]map[workerSpecificConfigOption]any
+	workerSpecificConfig map[WorkerType]map[WorkerSpecificConfigOption]any
 	environment.CommandEnvironment
 	*unPingableNodes // Pointer to an unPingableNodes object that indicates which configured nodes in Nodes do not respond to a ping request
 }
@@ -154,12 +154,12 @@ func (c *Config) IsNodeUnpingable(node string) bool {
 }
 
 // initializeWorkerSpecificConfigDefaults initializes and returns a map of default configuration values for each worker type.
-func initializeWorkerSpecificConfigDefaults() map[WorkerType]map[workerSpecificConfigOption]any {
-	m := make(map[WorkerType]map[workerSpecificConfigOption]any, 0)
+func initializeWorkerSpecificConfigDefaults() map[WorkerType]map[WorkerSpecificConfigOption]any {
+	m := make(map[WorkerType]map[WorkerSpecificConfigOption]any, 0)
 
 	for i := WorkerType(0); i < invalidWorkerType; i++ {
-		m[i] = make(map[workerSpecificConfigOption]any, 0)
-		m[i][numRetriesOption] = retryDefault
+		m[i] = make(map[WorkerSpecificConfigOption]any, 0)
+		m[i][NumRetriesOption] = retryDefault
 	}
 
 	return m

--- a/internal/worker/config_test.go
+++ b/internal/worker/config_test.go
@@ -208,9 +208,9 @@ func TestBackupConfig(t *testing.T) {
 	}
 	c1.unPingableNodes = &unPingableNodes{sync.Map{}}
 	c1.unPingableNodes.Store("foo", struct{}{})
-	c1.workerSpecificConfig = map[WorkerType]map[workerSpecificConfigOption]any{
+	c1.workerSpecificConfig = map[WorkerType]map[WorkerSpecificConfigOption]any{
 		PushTokensWorkerType: {
-			numRetriesOption: 5,
+			NumRetriesOption: 5,
 		},
 	}
 
@@ -246,7 +246,7 @@ func TestInitializeWorkerSpecificConfigDefaults(t *testing.T) {
 		if !ok {
 			t.Errorf("Expected key %v not found in map", wt)
 		}
-		valInt, ok := val[numRetriesOption].(int)
+		valInt, ok := val[NumRetriesOption].(int)
 		if !ok {
 			t.Errorf("Expected value of type int, got %T", m[wt])
 		}

--- a/internal/worker/supportedExtrasKey.go
+++ b/internal/worker/supportedExtrasKey.go
@@ -22,9 +22,11 @@ type supportedExtrasKey int
 const (
 	// DefaultRoleFileTemplate is a key to store the value of the default role file template in the Config.Extras map
 	DefaultRoleFileDestinationTemplate supportedExtrasKey = iota
+	// FileCopierOptions allows the user to specify options for the file copier
 	FileCopierOptions
-	VaultTokenStoreHoldoff
+	// PingOptions allows the user to specify options for the PingAggregatorWorker to use
 	PingOptions
+	// SSHOptions allows the user to specify options for the PushTokensWorker to use when pushing files to the destination nodes
 	SSHOptions
 )
 
@@ -34,8 +36,6 @@ func (s supportedExtrasKey) String() string {
 		return "DefaultRoleFileDestinationTemplate"
 	case FileCopierOptions:
 		return "FileCopierOptions"
-	case VaultTokenStoreHoldoff:
-		return "VaultTokenStoreHoldoff"
 	case PingOptions:
 		return "PingOptions"
 	case SSHOptions:
@@ -64,18 +64,6 @@ func SetSupportedExtrasKeyValue(key supportedExtrasKey, value any) func(*Config)
 func GetDefaultRoleFileDestinationTemplateValueFromExtras(c *Config) (string, bool) {
 	defaultRoleFileDestinationTemplateString, ok := c.Extras[DefaultRoleFileDestinationTemplate].(string)
 	return defaultRoleFileDestinationTemplateString, ok
-}
-
-// GetVaultTokenStoreHoldoff returns the value from the Config for the Extras VaultTokenStoreHoldoff key.
-// It also returns a bool, ok, indicating whether this value should be used or not.
-func GetVaultTokenStoreHoldoff(c *Config) (holdoff bool, ok bool) {
-	holdoff, ok = c.Extras[VaultTokenStoreHoldoff].(bool)
-	return holdoff, ok
-}
-
-// SetVaultTokenStoreHoldoff returns a func(*Config) that sets the VaultTokenStoreHoldoff Extras key of the *Config to true
-func SetVaultTokenStoreHoldoff() func(*Config) error {
-	return SetSupportedExtrasKeyValue(VaultTokenStoreHoldoff, true)
 }
 
 // defaultFileCopierOpts assumes that the FileCopier will implement rsync, and thus the default options will render the

--- a/internal/worker/supportedExtrasKey_test.go
+++ b/internal/worker/supportedExtrasKey_test.go
@@ -23,61 +23,6 @@ import (
 	"github.com/fermitools/managed-tokens/internal/service"
 )
 
-func TestGetVaultTokenStoreHoldoff(t *testing.T) {
-	testService := service.NewService("test_service")
-
-	type testCase struct {
-		description     string
-		setKeyValFunc   func(*Config) error
-		expectedHoldoff bool
-		expectedOk      bool
-	}
-
-	testCases := []testCase{
-		{
-			"Nothing set",
-			func(c *Config) error { return nil },
-			false,
-			false,
-		},
-		{
-			"Valid setting",
-			SetSupportedExtrasKeyValue(VaultTokenStoreHoldoff, true),
-			true,
-			true,
-		},
-		{
-			"Invalid setting",
-			SetSupportedExtrasKeyValue(VaultTokenStoreHoldoff, 12345),
-			false,
-			false,
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(
-			test.description,
-			func(t *testing.T) {
-				config, _ := NewConfig(testService, test.setKeyValFunc)
-				holdoff, ok := GetVaultTokenStoreHoldoff(config)
-				assert.Equal(t, test.expectedHoldoff, holdoff)
-				assert.Equal(t, test.expectedOk, ok)
-			},
-		)
-	}
-}
-
-func TestSetVaultTokenStoreHoldoff(t *testing.T) {
-	config, _ := NewConfig(service.NewService("test_service"), SetVaultTokenStoreHoldoff())
-	val, ok := config.Extras[VaultTokenStoreHoldoff]
-	assert.True(t, ok, "VaultTokenStoreHoldoff assignment not made:  Key not present in Extras map")
-	valBool, ok := val.(bool)
-	if !ok {
-		t.Error("Stored value failed type check")
-	}
-	assert.True(t, valBool, "Stored value should be true.  Got false instead")
-}
-
 func TestGetDefaultRoleFileDestinationTemplateValueFromExtras(t *testing.T) {
 	testService := service.NewService("test_service")
 

--- a/internal/worker/workerSpecificConfig_test.go
+++ b/internal/worker/workerSpecificConfig_test.go
@@ -16,37 +16,18 @@
 package worker
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSetWorkerNumRetriesValue(t *testing.T) {
-	opt := SetWorkerNumRetriesValue(GetKerberosTicketsWorkerType, 5)
-	c := &Config{}
-	c.workerSpecificConfig = make(map[WorkerType]map[workerSpecificConfigOption]any)
-	c.workerSpecificConfig[GetKerberosTicketsWorkerType] = make(map[workerSpecificConfigOption]any, 0)
-
-	err := opt(c)
-	assert.Nil(t, err)
-
-	val, ok := c.workerSpecificConfig[GetKerberosTicketsWorkerType]
-	if !ok {
-		t.Errorf("Expected workerSpecificConfig to contain GetKerberosTicketsWorkerType")
-	}
-
-	valInt, ok := val[numRetriesOption].(uint)
-	if !ok {
-		t.Errorf("Expected value to be of type uint")
-	}
-	assert.Equal(t, uint(5), valInt)
-}
 func TestGetWorkerRetryValueFromConfig(t *testing.T) {
 	c := &Config{}
-	c.workerSpecificConfig = make(map[WorkerType]map[workerSpecificConfigOption]any)
-	c.workerSpecificConfig[GetKerberosTicketsWorkerType] = make(map[workerSpecificConfigOption]any, 0)
-	c.workerSpecificConfig[GetKerberosTicketsWorkerType][numRetriesOption] = uint(5)
+	c.workerSpecificConfig = make(map[WorkerType]map[WorkerSpecificConfigOption]any)
+	c.workerSpecificConfig[GetKerberosTicketsWorkerType] = make(map[WorkerSpecificConfigOption]any, 0)
+	c.workerSpecificConfig[GetKerberosTicketsWorkerType][NumRetriesOption] = uint(5)
 
 	// Test case: Worker type exists in the config
 	val, err := getWorkerNumRetriesValueFromConfig(*c, GetKerberosTicketsWorkerType)
@@ -59,49 +40,26 @@ func TestGetWorkerRetryValueFromConfig(t *testing.T) {
 	assert.Equal(t, uint(0), val)
 
 	// Test case: Worker type exists in the config but value is not of type uint
-	c.workerSpecificConfig[GetKerberosTicketsWorkerType][numRetriesOption] = "invalid"
+	c.workerSpecificConfig[GetKerberosTicketsWorkerType][NumRetriesOption] = "invalid"
 	val, err = getWorkerNumRetriesValueFromConfig(*c, GetKerberosTicketsWorkerType)
 	assert.NotNil(t, err)
 	assert.Equal(t, uint(0), val)
 }
 func TestIsValidWorkerSpecificConfigOption(t *testing.T) {
 	// Test case: Valid worker specific config option
-	validOption := isValidWorkerSpecificConfigOption(numRetriesOption)
+	validOption := isValidWorkerSpecificConfigOption(NumRetriesOption)
 	assert.True(t, validOption)
 
 	// Test case: Invalid worker specific config option
-	invalidOption := isValidWorkerSpecificConfigOption(workerSpecificConfigOption(2))
+	invalidOption := isValidWorkerSpecificConfigOption(WorkerSpecificConfigOption(2))
 	assert.False(t, invalidOption)
-}
-func TestSetWorkerRetrySleepValue(t *testing.T) {
-	opt := SetWorkerRetrySleepValue(GetKerberosTicketsWorkerType, 5*time.Second)
-	c := &Config{}
-	c.workerSpecificConfig = make(map[WorkerType]map[workerSpecificConfigOption]any)
-	c.workerSpecificConfig[GetKerberosTicketsWorkerType] = make(map[workerSpecificConfigOption]any, 0)
-
-	// Make sure our returned ConfigOption works
-	err := opt(c)
-	assert.Nil(t, err)
-
-	// Make sure the top-level map was intialized correctly
-	val, ok := c.workerSpecificConfig[GetKerberosTicketsWorkerType]
-	if !ok {
-		t.Errorf("Expected workerSpecificConfig to contain GetKerberosTicketsWorkerType")
-	}
-
-	// Check that the value was set correctly
-	valDuration, ok := val[retrySleepOption].(time.Duration)
-	if !ok {
-		t.Errorf("Expected value to be of type time.Duration")
-	}
-	assert.Equal(t, 5*time.Second, valDuration)
 }
 
 func TestGetWorkerRetrySleepValueFromConfig(t *testing.T) {
 	c := &Config{}
-	c.workerSpecificConfig = make(map[WorkerType]map[workerSpecificConfigOption]any)
-	c.workerSpecificConfig[GetKerberosTicketsWorkerType] = make(map[workerSpecificConfigOption]any, 0)
-	c.workerSpecificConfig[GetKerberosTicketsWorkerType][retrySleepOption] = 5 * time.Second
+	c.workerSpecificConfig = make(map[WorkerType]map[WorkerSpecificConfigOption]any)
+	c.workerSpecificConfig[GetKerberosTicketsWorkerType] = make(map[WorkerSpecificConfigOption]any, 0)
+	c.workerSpecificConfig[GetKerberosTicketsWorkerType][RetrySleepOption] = 5 * time.Second
 
 	// Test case: Worker type exists in the config
 	val, err := getWorkerRetrySleepValueFromConfig(*c, GetKerberosTicketsWorkerType)
@@ -114,8 +72,81 @@ func TestGetWorkerRetrySleepValueFromConfig(t *testing.T) {
 	assert.Equal(t, time.Duration(0), val)
 
 	// Test case: Worker type exists in the config but value is not of type time.Duration
-	c.workerSpecificConfig[GetKerberosTicketsWorkerType][retrySleepOption] = "invalid"
+	c.workerSpecificConfig[GetKerberosTicketsWorkerType][RetrySleepOption] = "invalid"
 	val, err = getWorkerRetrySleepValueFromConfig(*c, GetKerberosTicketsWorkerType)
 	assert.NotNil(t, err)
 	assert.Equal(t, time.Duration(0), val)
+}
+
+func TestSetWorkerSpecificConfigOption(t *testing.T) {
+	type testCase struct {
+		description    string
+		workerType     WorkerType
+		option         WorkerSpecificConfigOption
+		value          any
+		expectedConfig *Config
+		expectedErr    error
+	}
+
+	testCases := []testCase{
+		{
+			description: "Set NumRetries option",
+			workerType:  GetKerberosTicketsWorkerType,
+			option:      NumRetriesOption,
+			value:       5,
+			expectedConfig: &Config{
+				workerSpecificConfig: map[WorkerType]map[WorkerSpecificConfigOption]any{
+					GetKerberosTicketsWorkerType: {
+						NumRetriesOption: 5,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "Set RetrySleep option",
+			workerType:  GetKerberosTicketsWorkerType,
+			option:      RetrySleepOption,
+			value:       5 * time.Second,
+			expectedConfig: &Config{
+				workerSpecificConfig: map[WorkerType]map[WorkerSpecificConfigOption]any{
+					GetKerberosTicketsWorkerType: {
+						RetrySleepOption: 5 * time.Second,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			description:    "Invalid worker type",
+			workerType:     invalidWorkerType,
+			option:         NumRetriesOption,
+			value:          5,
+			expectedConfig: nil,
+			expectedErr:    errors.New("invalid worker type"),
+		},
+		{
+			description:    "Invalid worker specific config option",
+			workerType:     GetKerberosTicketsWorkerType,
+			option:         invalidWorkerSpecificConfigOption,
+			value:          5,
+			expectedConfig: nil,
+			expectedErr:    errors.New("invalid worker-specific configuration option"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c := &Config{}
+			c.workerSpecificConfig = make(map[WorkerType]map[WorkerSpecificConfigOption]any)
+			err := SetWorkerSpecificConfigOption(tc.workerType, tc.option, tc.value)(c)
+			if tc.expectedErr == nil {
+				assert.Nil(t, err)
+				assert.Equal(t, *tc.expectedConfig, *c)
+				return
+			}
+			// Non-nil error, so make sure our error message is correct
+			assert.ErrorContains(t, err, tc.expectedErr.Error())
+		})
+	}
 }


### PR DESCRIPTION
This addresses the concerns in #114 and #115 about DRY and cleaning up the code wrt the `workerSpecificConfigOption` setters and getters.

The changes can be summarized as follows:

### package `internal/worker`
1. Export `worker.WorkerSpecificConfigOption` type and its enumerated `const` values.
2. Replace exported setters of that type with a single exported function `SetWorkerSpecificConfigOption`
3. (Unrelated) Deprecate `VaultTokenStoreHoldoff` const of type `supportedExtrasKey`

## package `cmd/token-push`
1. Update func `setAllWorkerRetryValues` to use `worker.SetWorkerSpecificConfigOption`
2. Remove functions setting `VaultTokenStoreHoldoff` in light of (3) above.
3. Move func `getAndCheckRetryInfoFromConfig` to `config.go`, where I think it fits better
4. Create workerRetryMap that will eventually get used to set `worker.WorkerSpecificConfigOption` in its own utility function to clean up func `run` in `main.go`.

Closes #114
Closes #115 
