### PR TITLE
In the original jsonnet implementation, I forgot to take into account multi-role experiments

### DIFF
--- a/.github/actions/setup-jsonnet-and-go/action.yaml
+++ b/.github/actions/setup-jsonnet-and-go/action.yaml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.22'
+        go-version: ${{ vars.ACTION_GOVERSION }}
 
     - name: Set up jsonnet
       shell: bash

--- a/.github/actions/setup-jsonnet-and-go/action.yaml
+++ b/.github/actions/setup-jsonnet-and-go/action.yaml
@@ -1,0 +1,12 @@
+name: "Set up go and jsonnet"
+description: "This action sets up Go and jsonnet"
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '1.22'
+
+    - name: Set up jsonnet
+      shell: bash
+      run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -1,7 +1,7 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
-name: Go build/test
+name: Go build and test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22'
+        go-version: ${{ vars.ACTION_GOVERSION }}
 
     - name: Populate vendor dir
       run: go mod vendor

--- a/.github/workflows/jsonnet_test.yml
+++ b/.github/workflows/jsonnet_test.yml
@@ -1,0 +1,38 @@
+# This workflow will run the jsonnet tests
+
+name: Jsonnet build and test
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+    CI: true
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v3
+        - uses: ./.github/actions/setup-jsonnet-and-go
+
+        - name: Render json from jsonnet file
+          run: make -f Makefile_jsonnet
+
+    test:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v3
+        - uses: ./.github/actions/setup-jsonnet-and-go
+
+        - name: Download jsonnetunit
+          uses: actions/checkout@v3
+          with:
+            repository: yugui/jsonnetunit
+            path: libsonnet/jsonnetunit
+
+        - name: Run jsonnet tests
+          run: make -f Makefile_jsonnet test

--- a/Makefile_jsonnet
+++ b/Makefile_jsonnet
@@ -1,17 +1,27 @@
 sourcefile := managedTokens.jsonnet
 outfile := managedTokens.json
+libsonnet_dir := libsonnet
+libsonnet_files := $(wildcard $(libsonnet_dir)/*.libsonnet)
+
+# Tests
 testfile := managedTokens_test.jsonnet
+jsonnetunit_dir := $(libsonnet_dir)/jsonnetunit
+libsonnet_test_files := $(wildcard $(libsonnet_dir)/*.jsonnet)
 
-.PHONY: clean test
+.PHONY: clean test test_top_level test_libsonnet
 
-$(outfile): $(sourcefile) libsonnet/*
+$(outfile): $(sourcefile) $(libsonnet_files)
 	jsonnet -o $@ $<
 
-test:  libsonnet/*.libsonnet libsonnet/jsonnetunit libsonnet/*.jsonnet
-	jsonnet -J libsonnet/jsonnetunit  $(testfile)
-	cd libsonnet; \
-	jsonnet -J jsonnetunit *.jsonnet
+all: test $(outfile)
 
+test: test_top_level test_libsonnet
+
+test_top_level:  $(testfile) $(libsonnet_files) $(jsonnetunit_dir)
+	jsonnet -J $(jsonnetunit_dir) $<
+
+test_libsonnet: $(libsonnet_test_files) $(libsonnet_files) $(jsonnetunit_dir)
+	jsonnet -J $(jsonnetunit_dir) $<
 
 clean: ${outfile}
 	rm $<

--- a/Makefile_jsonnet
+++ b/Makefile_jsonnet
@@ -1,10 +1,17 @@
 sourcefile := managedTokens.jsonnet
 outfile := managedTokens.json
+testfile := managedTokens_test.jsonnet
 
-.PHONY: clean
+.PHONY: clean test
 
 $(outfile): $(sourcefile) libsonnet/*
 	jsonnet -o $@ $<
+
+test:  libsonnet/*.libsonnet libsonnet/jsonnetunit libsonnet/*.jsonnet
+	jsonnet -J libsonnet/jsonnetunit  $(testfile)
+	cd libsonnet; \
+	jsonnet -J jsonnetunit *.jsonnet
+
 
 clean: ${outfile}
 	rm $<

--- a/libsonnet/experimentConfig.libsonnet
+++ b/libsonnet/experimentConfig.libsonnet
@@ -35,9 +35,9 @@ local supportedOverrides = [
     // given by the caller against the supported overrides
     //
     // This is the recommended way to create roleConfig objects
-    makeRoleConfig(account, nodes, overrides={}): {
+    makeRoleConfig(account, destinationNodes, overrides={}): {
             account: account,
-            destinationNodes: nodes,
+            destinationNodes: destinationNodes,
     } + {
             [ov]: overrides[ov],
             for ov in std.objectFields(overrides)

--- a/libsonnet/experimentConfig.libsonnet
+++ b/libsonnet/experimentConfig.libsonnet
@@ -1,7 +1,6 @@
 // Object for experiment configurations, along with a function that creates this object
 
 local supportedOverrides = [
-    "experimentOverride",
     "keytabPathOverride",
     "userPrincipalOverride",
     "desiredUIDOverride",
@@ -12,22 +11,36 @@ local supportedOverrides = [
 ];
 
 {
+    // func makeConfig(emails []string, roleConfigs map[string]roleConfig, experimentOverride string, otherOverrides map[string]any)
     // makeConfig creates an experiment configuration object, and checks any overrides given by the caller
     // note: overrides is a dictionary of key-value pairs that will be merged into the experiment config
-    makeConfig(emails, role, account, nodes, overrides={}): {
+    //
+    // At minimum, the caller must provide a list of emails and a map of roleConfigs
+    // It is recommended to use makeRoleConfig to create roleConfig objects
+    //
+    // If overrides are given both in the roleConfigs and in otherOverrides here,
+    // the roleConfigs will take precedence
+    makeConfig(emails, roleConfigs, experimentOverride="", otherOverrides={}): {
         emails: emails,
     } + {
-            [if std.objectHas(overrides, "experimentOverride") then "experimentOverride"]:  overrides.experimentOverride ,
+            [if experimentOverride != "" then "experimentOverride"]: experimentOverride,
     } + {
         roles: {
-            [role]: {
-                account: account,
-                destinationNodes: nodes,
-            } + {
-                [ov]: overrides[ov],
-                for ov in std.objectFields(overrides)
-                if ov != "experimentOverride" && std.member(supportedOverrides, ov)
-            }
+            [r]: otherOverrides + roleConfigs[r] // otherOverrides goes first so that it can be overridden by the roleConfig's overrides field
+            for r in std.objectFields(roleConfigs)
         },
+    },
+    // func makeRoleConfig(account string, nodes []string, overrides map[string]any)
+    // makeRoleConfig creates a role configuration object, and checks any overrides
+    // given by the caller against the supported overrides
+    //
+    // This is the recommended way to create roleConfig objects
+    makeRoleConfig(account, nodes, overrides={}): {
+            account: account,
+            destinationNodes: nodes,
+    } + {
+            [ov]: overrides[ov],
+            for ov in std.objectFields(overrides)
+            if std.member(supportedOverrides, ov)
     }
 }

--- a/libsonnet/experimentConfig_test.jsonnet
+++ b/libsonnet/experimentConfig_test.jsonnet
@@ -1,0 +1,152 @@
+local test = import "jsonnetunit/test.libsonnet";
+local exptConfig = import "experimentConfig.libsonnet";
+
+test.suite({
+    testSimpleCase: {
+        actual: exptConfig.makeConfig(
+            emails=["test1@example.com", "test2@example.com"],
+            roleConfigs={
+                "role1": exptConfig.makeRoleConfig(
+                    account="testaccount",
+                    destinationNodes=["testnode1", "testnode2"],
+                )
+            }
+        ),
+        expect: {
+            "emails":  ["test1@example.com", "test2@example.com"],
+            "roles": {
+                "role1": {
+                    "account": "testaccount",
+                    "destinationNodes": ["testnode1", "testnode2"],
+                },
+            },
+        },
+    },
+    testMultipleRolesCase: {
+        actual: exptConfig.makeConfig(
+            emails=["test1@example.com", "test2@example.com"],
+            roleConfigs={
+                "role1": exptConfig.makeRoleConfig(
+                    account="testaccount1",
+                    destinationNodes=["testnode1", "testnode2"],
+                ),
+                "role2": exptConfig.makeRoleConfig(
+                    account="testaccount2",
+                    destinationNodes=["testnode3", "testnode4"],
+                ),
+            },
+        ),
+        expect: {
+            "emails": ["test1@example.com", "test2@example.com"],
+            "roles": {
+                "role1": {
+                    "account": "testaccount1",
+                    "destinationNodes": ["testnode1", "testnode2"],
+                },
+                "role2": {
+                    "account": "testaccount2",
+                    "destinationNodes": ["testnode3", "testnode4"],
+                },
+            },
+        },
+    },
+    testOverridesCase: {
+        actual: exptConfig.makeConfig(
+            emails=["test1@example.com", "test2@example.com"],
+            experimentOverride="realexperiment",
+            roleConfigs={
+                "testrole": exptConfig.makeRoleConfig(
+                    account="testaccount",
+                    destinationNodes=["testnode1", "testnode2"],
+                    overrides={
+                        keytabPathOverride: "/special/path/to/keytab",
+                        userPrincipalOverride: "otheraccount/kerberos/principal@REALM",
+                        desiredUIDOverride: 12345,
+                        condorCreddHostOverride: "specialcreddhost.domain",
+                        condorCollectorHostOverride: "specialcollectorhost.domain",
+                        defaultRoleFileDestinationTemplateOverride: "/tmp/{{.DesiredUID}}_{{.Account}}",  # Any field in the worker.Config object is supported here
+                        disableNotificationsOverride: false, # If true, no notifications will be sent for this role
+                    },
+                ),
+            },
+        ),
+        expect: {
+            "emails": ["test1@example.com", "test2@example.com"],
+            "experimentOverride": "realexperiment",
+            "roles": {
+                "testrole": {
+                    "account": "testaccount",
+                    "destinationNodes": ["testnode1", "testnode2"],
+                    keytabPathOverride: "/special/path/to/keytab",
+                    userPrincipalOverride: "otheraccount/kerberos/principal@REALM",
+                    desiredUIDOverride: 12345,
+                    condorCreddHostOverride: "specialcreddhost.domain",
+                    condorCollectorHostOverride: "specialcollectorhost.domain",
+                    defaultRoleFileDestinationTemplateOverride: "/tmp/{{.DesiredUID}}_{{.Account}}",  # Any field in the worker.Config object is supported here
+                    disableNotificationsOverride: false, # If true, no notifications will be sent for this role
+                },
+            },
+        },
+    },
+    testInvalidOverrideCase: {
+        actual: exptConfig.makeConfig(
+            emails=["test1@example.com", "test2@example.com"],
+            roleConfigs={
+                "testrole": exptConfig.makeRoleConfig(
+                    account="testaccount",
+                    destinationNodes=["testnode1", "testnode2"],
+                    overrides={
+                        invalidOverride: "this should be ignored",
+                    },
+                ),
+            },
+        ),
+        expect: {
+            "emails": ["test1@example.com", "test2@example.com"],
+            "roles": {
+                "testrole": {
+                    "account": "testaccount",
+                    "destinationNodes": ["testnode1", "testnode2"],
+                },
+            },
+        },
+    },
+    testExptAndRoleOverridesCase: {
+        actual: exptConfig.makeConfig(
+            emails=["test1@example.com", "test2@example.com"],
+            experimentOverride="realexperiment",
+            otherOverrides={
+                disableNotificationsOverride: true, # If true, no notifications will be sent for this role
+            },
+            roleConfigs={
+                "testrole": exptConfig.makeRoleConfig(
+                    account="testaccount1",
+                    destinationNodes=["testnode1", "testnode2"],
+                    overrides={
+                        disableNotificationsOverride: false, # If true, no notifications will be sent for this role
+                    },
+                ),
+                "testrole2": exptConfig.makeRoleConfig(
+                    account="testaccount2",
+                    destinationNodes=["testnode3", "testnode4"],
+                ),
+            },
+        ),
+        expect: {
+            "emails": ["test1@example.com", "test2@example.com"],
+            "experimentOverride": "realexperiment",
+            "roles": {
+                "testrole": {
+                    "account": "testaccount1",
+                    "destinationNodes": ["testnode1", "testnode2"],
+                    "disableNotificationsOverride": false, # If true, no notifications will be sent for this role
+                },
+                "testrole2": {
+                    "account": "testaccount2",
+                    "destinationNodes": ["testnode3", "testnode4"],
+                    "disableNotificationsOverride": true, # If true, no notifications will be sent for this role
+                },
+            },
+        },
+    },
+})

--- a/managedTokens.jsonnet
+++ b/managedTokens.jsonnet
@@ -11,31 +11,82 @@ local notificationsConfig = import 'libsonnet/notificationsConfig.libsonnet';
         // Minimum-required configs
         dune: exptConfig.makeConfig(
             emails=["email1@example.com"],
-            role="production",
-            account="dunepro",
-            nodes=["dune01.fnal.gov", "dune02", "dune03"],
+            roleConfigs={
+                "production": exptConfig.makeRoleConfig(
+                    account="dunepro",
+                    nodes=["dune01", "dune02", "dune03"],
+                ),
+            }
         ),
         mu2e: exptConfig.makeConfig(
             emails=["email2@example.com"],
-            role="production",
-            account="mu2epro",
-            nodes=["mu2e01.fnal.gov", "mu2e02", "mu2e03"],
+            roleConfigs={
+                "production": exptConfig.makeRoleConfig(
+                    account="mu2epro",
+                    nodes=["mu2e01", "mu2e02", "mu2e03"],
+                ),
+            }
+        ),
+        // Configs with multiple roles
+        "sbnd": exptConfig.makeConfig(
+            emails=["email1@example.com"],
+            roleConfigs={
+                "production": exptConfig.makeRoleConfig(
+                    account="sbndpro",
+                    nodes=["sbnd01", "sbnd02", "sbnd03"],
+                ),
+                "testrole": exptConfig.makeRoleConfig(
+                    account="sbndtestrole",
+                    nodes=["sbnd01", "sbnd02", "sbnd03"],
+                ),
+            }
         ),
         // Configs with overrides
         "dune-2": exptConfig.makeConfig(
             emails=["email1@example.com"],
-            role="production",
-            account="dunepro",
-            nodes=["dune01.fnal.gov", "dune02", "dune03"],
-            overrides={
-                experimentOverride: "dune",
-                keytabPathOverride: "/special/path/to/keytab",
-                userPrincipalOverride: "dunepro/kerberos/principal@REALM",
-                desiredUIDOverride: 12345,
-                condorCreddHostOverride: "specialcreddhost.domain",
-                condorCollectorHostOverride: "specialcollectorhost.domain",
-                defaultRoleFileDestinationTemplateOverride: "/tmp/{{.DesiredUID}}_{{.Account}}",  # Any field in the worker.Config object is supported here
-                disableNotificationsOverride: false, # If true, no notifications will be sent for this role
+            experimentOverride="dune",
+            roleConfigs={
+                "production": exptConfig.makeRoleConfig(
+                    account="dunepro",
+                    nodes=["dune01", "dune02", "dune03"],
+                    overrides={
+                        experimentOverride: "dune",
+                        keytabPathOverride: "/special/path/to/keytab",
+                        userPrincipalOverride: "dunepro/kerberos/principal@REALM",
+                        desiredUIDOverride: 12345,
+                        condorCreddHostOverride: "specialcreddhost.domain",
+                        condorCollectorHostOverride: "specialcollectorhost.domain",
+                        defaultRoleFileDestinationTemplateOverride: "/tmp/{{.DesiredUID}}_{{.Account}}",  # Any field in the worker.Config object is supported here
+                        disableNotificationsOverride: false, # If true, no notifications will be sent for this role
+                    },
+                ),
+            },
+        ),
+        // Config with experiment-level overrides and role-level overrides:
+        "sbnd-2": exptConfig.makeConfig(
+            emails=["email2@example.com"],
+            experimentOverride="sbnd",
+            otherOverrides = {
+                disableNotificationsOverride: true, # If true, no notifications will be sent for this role
+            },
+            roleConfigs={
+                "production": exptConfig.makeRoleConfig(
+                    account="sbndpro",
+                    nodes=["sbnd01", "sbnd02", "sbnd03"],
+                    overrides={
+                        keytabPathOverride: "/special/path/to/keytab",
+                        userPrincipalOverride: "sbndpro/kerberos/principal@REALM",
+                        desiredUIDOverride: 12345,
+                        condorCreddHostOverride: "specialcreddhost.domain",
+                        condorCollectorHostOverride: "specialcollectorhost.domain",
+                        defaultRoleFileDestinationTemplateOverride: "/tmp/{{.DesiredUID}}_{{.Account}}",  # Any field in the worker.Config object is supported here
+                        disableNotificationsOverride: false, # If true, no notifications will be sent for this role
+                    },
+                ),
+                "testrole": exptConfig.makeRoleConfig(
+                    account="sbndtest",
+                    nodes=["sbnd01", "sbnd02", "sbnd03"],
+                ),
             },
         ),
     },

--- a/managedTokens.jsonnet
+++ b/managedTokens.jsonnet
@@ -14,7 +14,7 @@ local notificationsConfig = import 'libsonnet/notificationsConfig.libsonnet';
             roleConfigs={
                 "production": exptConfig.makeRoleConfig(
                     account="dunepro",
-                    nodes=["dune01", "dune02", "dune03"],
+                    destinationNodes=["dune01", "dune02", "dune03"],
                 ),
             }
         ),
@@ -23,7 +23,7 @@ local notificationsConfig = import 'libsonnet/notificationsConfig.libsonnet';
             roleConfigs={
                 "production": exptConfig.makeRoleConfig(
                     account="mu2epro",
-                    nodes=["mu2e01", "mu2e02", "mu2e03"],
+                    destinationNodes=["mu2e01", "mu2e02", "mu2e03"],
                 ),
             }
         ),
@@ -33,11 +33,11 @@ local notificationsConfig = import 'libsonnet/notificationsConfig.libsonnet';
             roleConfigs={
                 "production": exptConfig.makeRoleConfig(
                     account="sbndpro",
-                    nodes=["sbnd01", "sbnd02", "sbnd03"],
+                    destinationNodes=["sbnd01", "sbnd02", "sbnd03"],
                 ),
                 "testrole": exptConfig.makeRoleConfig(
                     account="sbndtestrole",
-                    nodes=["sbnd01", "sbnd02", "sbnd03"],
+                    destinationNodes=["sbnd01", "sbnd02", "sbnd03"],
                 ),
             }
         ),
@@ -48,7 +48,7 @@ local notificationsConfig = import 'libsonnet/notificationsConfig.libsonnet';
             roleConfigs={
                 "production": exptConfig.makeRoleConfig(
                     account="dunepro",
-                    nodes=["dune01", "dune02", "dune03"],
+                    destinationNodes=["dune01", "dune02", "dune03"],
                     overrides={
                         experimentOverride: "dune",
                         keytabPathOverride: "/special/path/to/keytab",
@@ -72,7 +72,7 @@ local notificationsConfig = import 'libsonnet/notificationsConfig.libsonnet';
             roleConfigs={
                 "production": exptConfig.makeRoleConfig(
                     account="sbndpro",
-                    nodes=["sbnd01", "sbnd02", "sbnd03"],
+                    destinationNodes=["sbnd01", "sbnd02", "sbnd03"],
                     overrides={
                         keytabPathOverride: "/special/path/to/keytab",
                         userPrincipalOverride: "sbndpro/kerberos/principal@REALM",
@@ -85,7 +85,7 @@ local notificationsConfig = import 'libsonnet/notificationsConfig.libsonnet';
                 ),
                 "testrole": exptConfig.makeRoleConfig(
                     account="sbndtest",
-                    nodes=["sbnd01", "sbnd02", "sbnd03"],
+                    destinationNodes=["sbnd01", "sbnd02", "sbnd03"],
                 ),
             },
         ),

--- a/managedTokens_test.jsonnet
+++ b/managedTokens_test.jsonnet
@@ -1,0 +1,362 @@
+// This test is meant to be used to check the entirety of the managedTokens.jsonnet file.
+// Right now, the "actual" section should just be a copy-paste of the managedTokens.jsonnet file after the imports, and
+// the expected should be the expected output from running jsonnet on the managedTokens.jsonnet file.
+
+// Run by using the command: jsonnet -J libsonnet/jsonnetunit managedTokens_test.jsonnet
+
+// Currently, this process is a bit manual, but at least it gives us a test
+
+
+local test = import 'jsonnetunit/test.libsonnet';
+
+local exptConfig = import 'libsonnet/experimentConfig.libsonnet';
+local ferryConfig = import 'libsonnet/ferryConfig.libsonnet';
+local timeoutsConfig = import 'libsonnet/timeoutsConfig.libsonnet';
+local emailConfig = import 'libsonnet/emailConfig.libsonnet';
+local obsConfig = import 'libsonnet/observability.libsonnet';
+local notificationsConfig = import 'libsonnet/notificationsConfig.libsonnet';
+
+
+test.suite({
+    testSampleConfig: {
+        // This should just be a copy of the managedTokens.jsonnet contents after the imports
+        actual: {
+            # Experiment config items
+            experiments: {
+                // Minimum-required configs
+                dune: exptConfig.makeConfig(
+                    emails=["email1@example.com"],
+                    roleConfigs={
+                        "production": exptConfig.makeRoleConfig(
+                            account="dunepro",
+                            destinationNodes=["dune01", "dune02", "dune03"],
+                        ),
+                    }
+                ),
+                mu2e: exptConfig.makeConfig(
+                    emails=["email2@example.com"],
+                    roleConfigs={
+                        "production": exptConfig.makeRoleConfig(
+                            account="mu2epro",
+                            destinationNodes=["mu2e01", "mu2e02", "mu2e03"],
+                        ),
+                    }
+                ),
+                // Configs with multiple roles
+                "sbnd": exptConfig.makeConfig(
+                    emails=["email1@example.com"],
+                    roleConfigs={
+                        "production": exptConfig.makeRoleConfig(
+                            account="sbndpro",
+                            destinationNodes=["sbnd01", "sbnd02", "sbnd03"],
+                        ),
+                        "testrole": exptConfig.makeRoleConfig(
+                            account="sbndtestrole",
+                            destinationNodes=["sbnd01", "sbnd02", "sbnd03"],
+                        ),
+                    }
+                ),
+                // Configs with overrides
+                "dune-2": exptConfig.makeConfig(
+                    emails=["email1@example.com"],
+                    experimentOverride="dune",
+                    roleConfigs={
+                        "production": exptConfig.makeRoleConfig(
+                            account="dunepro",
+                            destinationNodes=["dune01", "dune02", "dune03"],
+                            overrides={
+                                experimentOverride: "dune",
+                                keytabPathOverride: "/special/path/to/keytab",
+                                userPrincipalOverride: "dunepro/kerberos/principal@REALM",
+                                desiredUIDOverride: 12345,
+                                condorCreddHostOverride: "specialcreddhost.domain",
+                                condorCollectorHostOverride: "specialcollectorhost.domain",
+                                defaultRoleFileDestinationTemplateOverride: "/tmp/{{.DesiredUID}}_{{.Account}}",  # Any field in the worker.Config object is supported here
+                                disableNotificationsOverride: false, # If true, no notifications will be sent for this role
+                            },
+                        ),
+                    },
+                ),
+                // Config with experiment-level overrides and role-level overrides:
+                "sbnd-2": exptConfig.makeConfig(
+                    emails=["email2@example.com"],
+                    experimentOverride="sbnd",
+                    otherOverrides = {
+                        disableNotificationsOverride: true, # If true, no notifications will be sent for this role
+                    },
+                    roleConfigs={
+                        "production": exptConfig.makeRoleConfig(
+                            account="sbndpro",
+                            destinationNodes=["sbnd01", "sbnd02", "sbnd03"],
+                            overrides={
+                                keytabPathOverride: "/special/path/to/keytab",
+                                userPrincipalOverride: "sbndpro/kerberos/principal@REALM",
+                                desiredUIDOverride: 12345,
+                                condorCreddHostOverride: "specialcreddhost.domain",
+                                condorCollectorHostOverride: "specialcollectorhost.domain",
+                                defaultRoleFileDestinationTemplateOverride: "/tmp/{{.DesiredUID}}_{{.Account}}",  # Any field in the worker.Config object is supported here
+                                disableNotificationsOverride: false, # If true, no notifications will be sent for this role
+                            },
+                        ),
+                        "testrole": exptConfig.makeRoleConfig(
+                            account="sbndtest",
+                            destinationNodes=["sbnd01", "sbnd02", "sbnd03"],
+                        ),
+                    },
+                ),
+            },
+
+            # Performance/timeouts
+            timeouts: timeoutsConfig,
+            minTokenLifetime: "3d", # If our vault token has less than this time left, get a new one
+
+
+            # Worker-specific configurations
+            # Make changes using makeWorkerTypeConfig function
+            local makeWorkerTypeConfig(numRetries=0, retrySleep="0s") = {
+            numRetries: numRetries,
+            retrySleep: retrySleep,
+            },
+            workerType: {
+                pushTokens: makeWorkerTypeConfig(numRetries=3, retrySleep="60s"),
+                getKerberosTickets: makeWorkerTypeConfig(), // Uses default values
+                storeAndGetToken: makeWorkerTypeConfig(),
+                storeAndGetTokenInteractive: makeWorkerTypeConfig(),
+                pingAggregator: makeWorkerTypeConfig(),
+            },
+
+            # Observability
+            logs: obsConfig.logs,
+            prometheus: obsConfig.prometheus,
+            loki: obsConfig.loki,
+            tracing: obsConfig.tracing,
+
+            # Notifications
+            email: emailConfig,
+            notifications: notificationsConfig.prod,
+            notifications_test: notificationsConfig.test,
+            errorCountToSendMessage: 3,
+
+            ferry: ferryConfig,
+
+            # Global config items that won't change as much
+            keytabPath: "/opt/managed-tokens/keytabs",
+            condorCollectorHost: "collectorhost.domain",
+            condorScheddConstraint: "my_constraint",
+            serviceCreddVaultTokenPathRoot: "/var/lib/managed-tokens/service-credd-vault-tokens",
+            kerberosPrincipalPattern: "principal_pattern",
+            dbLocation: "/var/lib/managed-tokens/managed-tokens.db",
+            defaultRoleFileDestinationTemplate: "/tmp/{{.DesiredUID}}_{{.Account}}", # Any field in the worker.Config object is supported here,
+            pingOptions: "--arg1 --arg2 value2", # Options to use with ping,
+            fileCopierOptions: "--perms --chmod=u=r,go=", # Extra options to give to the fileCopier utility - usually rsync,
+            sshOptions: "-o Arg1=val1 -o Arg2=val2", # Options to use with fileCopier to establish the SSH connection
+            disableNotifications: false, # If true, no notifications will be sent
+
+            # Optional, and should not be used in production.  Defaults to "production", but can be specified here
+            # or with environment variable MANAGED_TOKENS_DEV_ENVIRONMENT_LABEL
+            devEnvironmentLabel: "development",
+        },
+        // With any edits to the sample jsonnet file, we should update the expected results as well
+        expect: {
+            "condorCollectorHost": "collectorhost.domain",
+            "condorScheddConstraint": "my_constraint",
+            "dbLocation": "/var/lib/managed-tokens/managed-tokens.db",
+            "defaultRoleFileDestinationTemplate": "/tmp/{{.DesiredUID}}_{{.Account}}",
+            "devEnvironmentLabel": "development",
+            "disableNotifications": false,
+            "email": {
+                "from": "admin_email@example.com",
+                "smtpHost": "localhost",
+                "smtpPort": 25
+            },
+            "errorCountToSendMessage": 3,
+            "experiments": {
+                "dune": {
+                    "emails": [
+                        "email1@example.com"
+                    ],
+                    "roles": {
+                        "production": {
+                        "account": "dunepro",
+                        "destinationNodes": [
+                            "dune01",
+                            "dune02",
+                            "dune03"
+                        ]
+                        }
+                    }
+                },
+                "dune-2": {
+                    "emails": [
+                        "email1@example.com"
+                    ],
+                    "experimentOverride": "dune",
+                    "roles": {
+                        "production": {
+                        "account": "dunepro",
+                        "condorCollectorHostOverride": "specialcollectorhost.domain",
+                        "condorCreddHostOverride": "specialcreddhost.domain",
+                        "defaultRoleFileDestinationTemplateOverride": "/tmp/{{.DesiredUID}}_{{.Account}}",
+                        "desiredUIDOverride": 12345,
+                        "destinationNodes": [
+                            "dune01",
+                            "dune02",
+                            "dune03"
+                        ],
+                        "disableNotificationsOverride": false,
+                        "keytabPathOverride": "/special/path/to/keytab",
+                        "userPrincipalOverride": "dunepro/kerberos/principal@REALM"
+                        }
+                    }
+                },
+                "mu2e": {
+                    "emails": [
+                        "email2@example.com"
+                    ],
+                    "roles": {
+                        "production": {
+                        "account": "mu2epro",
+                        "destinationNodes": [
+                            "mu2e01",
+                            "mu2e02",
+                            "mu2e03"
+                        ]
+                        }
+                    }
+                },
+                "sbnd": {
+                    "emails": [
+                        "email1@example.com"
+                    ],
+                    "roles": {
+                        "production": {
+                        "account": "sbndpro",
+                        "destinationNodes": [
+                            "sbnd01",
+                            "sbnd02",
+                            "sbnd03"
+                        ]
+                        },
+                        "testrole": {
+                        "account": "sbndtestrole",
+                        "destinationNodes": [
+                            "sbnd01",
+                            "sbnd02",
+                            "sbnd03"
+                        ]
+                        }
+                    }
+                },
+                "sbnd-2": {
+                    "emails": [
+                        "email2@example.com"
+                    ],
+                    "experimentOverride": "sbnd",
+                    "roles": {
+                        "production": {
+                        "account": "sbndpro",
+                        "condorCollectorHostOverride": "specialcollectorhost.domain",
+                        "condorCreddHostOverride": "specialcreddhost.domain",
+                        "defaultRoleFileDestinationTemplateOverride": "/tmp/{{.DesiredUID}}_{{.Account}}",
+                        "desiredUIDOverride": 12345,
+                        "destinationNodes": [
+                            "sbnd01",
+                            "sbnd02",
+                            "sbnd03"
+                        ],
+                        "disableNotificationsOverride": false,
+                        "keytabPathOverride": "/special/path/to/keytab",
+                        "userPrincipalOverride": "sbndpro/kerberos/principal@REALM"
+                        },
+                        "testrole": {
+                        "account": "sbndtest",
+                        "destinationNodes": [
+                            "sbnd01",
+                            "sbnd02",
+                            "sbnd03"
+                        ],
+                        "disableNotificationsOverride": true
+                        }
+                    }
+                }
+            },
+            "ferry": {
+                "caPath": "path/to/certificates",
+                "host": "ferryhost.domain",
+                "hostCert": "/path/to/hostcert",
+                "hostKey": "/path/to/hostkey",
+                "port": 8445,
+                "serviceExperiment": "fermilab",
+                "serviceKerberosPrincipal": "/path/to/service_principal",
+                "serviceKeytabPath": "/path/to/service_kerberos_keytab",
+                "serviceRole": "",
+                "vaultServer": "vaultserver.domain"
+            },
+            "fileCopierOptions": "--perms --chmod=u=r,go=",
+            "kerberosPrincipalPattern": "principal_pattern",
+            "keytabPath": "/opt/managed-tokens/keytabs",
+            "logs": {
+                "refresh-uids-from-ferry": {
+                    "debugfile": "/var/log/refresh-uids-from-ferry.debug.log",
+                    "logfile": "/var/log/refresh-uids-from-ferry.log"
+                },
+                "token-push": {
+                    "debugfile": "/var/log/token-push.debug.log",
+                    "logfile": "/var/log/token-push.log"
+                }
+            },
+            "loki": {
+                "host": "hostname.domain"
+            },
+            "minTokenLifetime": "3d",
+            "notifications": {
+                "SLACK_ALERTS_URL": "https://hooks.slack.com/FILL_IN_URL_HERE",
+                "admin_email": "admin@example.com"
+            },
+            "notifications_test": {
+                "SLACK_ALERTS_URL": "https://hooks.slack.com/FILL_IN_URL_HERE",
+                "admin_email": "admin@example.com"
+            },
+            "pingOptions": "--arg1 --arg2 value2",
+            "prometheus": {
+                "host": "hostname.domain",
+                "jobname": "managed_tokens"
+            },
+            "serviceCreddVaultTokenPathRoot": "/var/lib/managed-tokens/service-credd-vault-tokens",
+            "sshOptions": "-o Arg1=val1 -o Arg2=val2",
+            "timeouts": {
+                "ferryRequestTimeout": "30s",
+                "globalTimeout": "300s",
+                "kerberosTimeout": "20s",
+                "pingTimeout": "10s",
+                "pushTimeout": "30s",
+                "vaultStorerTimeout": "60s"
+            },
+            "tracing": {
+                "url": "scheme://hostname.domain"
+            },
+            "workerType": {
+                "getKerberosTickets": {
+                    "numRetries": 0,
+                    "retrySleep": "0s"
+                },
+                "pingAggregator": {
+                    "numRetries": 0,
+                    "retrySleep": "0s"
+                },
+                "pushTokens": {
+                    "numRetries": 3,
+                    "retrySleep": "60s"
+                },
+                "storeAndGetToken": {
+                    "numRetries": 0,
+                    "retrySleep": "0s"
+                },
+                "storeAndGetTokenInteractive": {
+                    "numRetries": 0,
+                    "retrySleep": "0s"
+                }
+            }
+        }
+    },
+})


### PR DESCRIPTION
This PR adds the layer needed to generate multi-role experiment configs.  Now, the easiest way to generate an experiment config is:

```jsonnet
experiment_name: exptConfig.makeConfig(
  emails=["email@example.com"],
  roleConfigs={
    "role_name": exptConfig.makeRoleConfig(
       account="account_name",
       nodes=["node01","node02"],
    ),
  },
)
```
    