### PR TITLE
Revert "Move Go version to repository-level variable ACTION_GOVERSION"

### DIFF
--- a/.github/actions/setup-jsonnet-and-go/action.yaml
+++ b/.github/actions/setup-jsonnet-and-go/action.yaml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-go@v4
       with:
-        go-version: ${{ vars.ACTION_GOVERSION }}
+        go-version: '1.22'
 
     - name: Set up jsonnet
       shell: bash

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: ${{ vars.ACTION_GOVERSION }}
+        go-version: '1.22'
 
     - name: Populate vendor dir
       run: go mod vendor


### PR DESCRIPTION
This reverts commit 2105a7b9782f3f2f2c0df32f7429c92485450c8b.

The move to the repo-wide variable seems to fail for actions.